### PR TITLE
some scrollwrite changes

### DIFF
--- a/ScrollWrite/data/tables/scrollwrite-sct.tbm
+++ b/ScrollWrite/data/tables/scrollwrite-sct.tbm
@@ -9,20 +9,22 @@ function Scroll:Init()
 
 	self.Enabled = false
 	self.Lines = {}
+	self.InterfaceSound = 20
+	self.GameSound = ad.getSoundentry(10)
 
 end
 
 function Scroll:Clear()
 
-	self.Lines = {}
 	self.Enabled = false
+	self.Lines = {}
 
 end
 
-function Scroll:WriteFromFile(file, x, y, speed, visibletime, fadeout, sound, font, center, r, g, b)
+function Scroll:WriteFromFile(file, x, y, speed, visibletime, fadeout, sound, font, center, r, g, b, loop)
 
 	local pos = file:find(".txt", -4, true)
-	
+
 	if not pos then
 		file = file .. ".txt"
 	end
@@ -30,35 +32,36 @@ function Scroll:WriteFromFile(file, x, y, speed, visibletime, fadeout, sound, fo
 	if cf.fileExists(file, "data/fiction", true) then
 		local f = cf.openFile(file,"rb","data/fiction")
 		local data = f:read("*a")
-		self:Write(data, x, y, speed, visibletime, fadeout, sound, font, center, r, g, b)
+		self:Write(data, x, y, speed, visibletime, fadeout, sound, font, center, r, g, b, loop)
 		f:close()
 	end
 
 end
 
-function Scroll:Write(text, x, y, speed, visibletime, fadeout, sound, font, center, r, g, b)
+function Scroll:Write(text, x, y, speed, visibletime, fadeout, sound, font, center, r, g, b, loop)
 
 	if not self.Enabled then
 		self.Enabled = true
 	end
 
 	local t = {}
-	
+
 	if not text then
 		return
 	end
-		
+
 	if mn.Messages[text]:isValid() then
 		t.Text = mn.Messages[text]:getMessage(true)
 	else
 		t.Text = text
 	end
-	
+
 	t.X = x or 50
 	t.X = gr.getScreenWidth() * (t.X/100)
 	t.Y = y or 50
 	t.Y = gr.getScreenHeight() * (t.Y/100)
 	t.Speed = speed or 0.03
+	t.SoundDuration = #t.Text * t.Speed
 	t.Timestamp = mn.getMissionTime()
 	t.Time = visibletime or 5
 	t.FadeOut = fadeout or 0
@@ -75,63 +78,72 @@ function Scroll:Write(text, x, y, speed, visibletime, fadeout, sound, font, cent
 	end
 	t.Color = {r or 255, g or 255, b or 255}
 	t.Alpha = 255
-	
-	self.Lines[#self.Lines+1] = t	
+	if loop == true then
+		t.Loop = true
+	else
+		t.Loop = false
+	end
+
+	self.Lines[#self.Lines+1] = t
 
 end
 
 function Scroll:Draw()
 
 	local mTime = mn.getMissionTime()
-	
+
 	if #self.Lines > 0 then
 		local numLines = #self.Lines
 		for i = 1, numLines do
 			if self.Lines[i] then
-			local line = self.Lines[i]
-			if mTime < (line.Timestamp + line.Time + line.FadeOut) then
-				if line.Sound then
-					ad.playInterfaceSound(20)
-					line.Sound = nil
-				end
-				local toDraw = (mTime - line.Timestamp) / line.Speed
-				if toDraw > 0 then
-					local displayString = line.Text:sub(1, toDraw)
-					local lastChar = line.Text:sub(-1)					
-					local x, y = line.X, line.Y
-					
-					gr.CurrentFont = gr.Fonts[line.Font]
-					
-					if mTime > (line.Timestamp + line.Time) then
-						local t = mn.getMissionTime() - (line.Timestamp + line.Time)				
-						line.Alpha = self:Ease(t,255,-255,line.FadeOut)
+				local line = self.Lines[i]
+				if mTime < (line.Timestamp + line.Time + line.FadeOut) then
+					if line.Sound then
+						if line.Loop then
+							line.Handle = ad.playLoopingSound(self.GameSound)
+						else
+							ad.playInterfaceSound(self.InterfaceSound)
+						end
+						line.Sound = nil
 					end
-					
-					if lastChar == ">" then
-						line.Speed = 0.05
-					elseif lastChar == "\\n" then
-						line.Speed = 0.02
-					end
-					
-					gr.setColor(line.Color[1], line.Color[2], line.Color[3], line.Alpha)
-					
-					if line.Center then
-						x = line.X - (gr.getStringWidth(line.Text)/2)
-					end
+					local toDraw = (mTime - line.Timestamp) / line.Speed
+					if toDraw > 0 then
+						local displayString = line.Text:sub(1, toDraw)
+						local lastChar = line.Text:sub(-1)
+						local x, y = line.X, line.Y
 
-					finalString = displayString
+						gr.CurrentFont = gr.Fonts[line.Font]
 
-					
-					gr.drawString(finalString,x,y)
-					
+						if line.Handle and mTime > (line.Timestamp + line.SoundDuration) then
+							line.Handle:stop()
+							line.Handle = nil
+						end
+						if mTime > (line.Timestamp + line.Time) then
+							local t = mn.getMissionTime() - (line.Timestamp + line.Time)
+							line.Alpha = self:Ease(t,255,-255,line.FadeOut)
+						end
+
+						if lastChar == ">" then
+							line.Speed = 0.05
+						elseif lastChar == "\\n" then
+							line.Speed = 0.02
+						end
+
+						gr.setColor(line.Color[1], line.Color[2], line.Color[3], line.Alpha)
+
+						if line.Center then
+							x = line.X - (gr.getStringWidth(line.Text)/2)
+						end
+
+						gr.drawString(displayString,x,y)
+					end
 				end
-			end
 			else
 				table.remove(self.Lines,i)
 				numLines = numLines - 1
-				
+
 				if numLines == 0 then self.Enabled = false end
-				
+
 			end
 		end
 	end
@@ -143,9 +155,39 @@ function Scroll:Ease(t,b,c,d)
   return -c * t * (t - 2) + b
 end
 
-mn.LuaSEXPs["lua-scroll-write"].Action = function(text, x, y, speed, visibletime, fadeout, sound, font, center, r, g, b) Scroll:Write(text, x, y, speed/1000, visibletime/1000, fadeout/1000, sound, font, center, r, g, b) end
-mn.LuaSEXPs["lua-scroll-write-file"].Action = function(file, x, y, speed, visibletime, fadeout, sound, font, center, r, g, b) Scroll:WriteFromFile(file, x, y, speed/1000, visibletime/1000, fadeout/1000, sound, font, center, r, g, b) end
-mn.LuaSEXPs["lua-scroll-write-clear"].Action = function() Scroll:Clear() end
+function Scroll:SetInterfaceSound(idx)
+	if idx then
+		self.InterfaceSound = idx
+	end
+end
+
+-- this function accepts strings or soundentry types
+function Scroll:SetGameSound(entry)
+	if entry then
+		if type(entry) == "string" then
+			entry = ad.getSoundentry(entry)
+		end
+		if entry:isValid() then
+			self.GameSound = entry
+		end
+	end
+end
+
+mn.LuaSEXPs["lua-scroll-write"].Action = function(text, x, y, speed, visibletime, fadeout, sound, font, center, r, g, b, loop)
+  Scroll:Write(text, x, y, speed/1000, visibletime/1000, fadeout/1000, sound, font, center, r, g, b, loop)
+end
+mn.LuaSEXPs["lua-scroll-write-file"].Action = function(file, x, y, speed, visibletime, fadeout, sound, font, center, r, g, b, loop)
+  Scroll:WriteFromFile(file, x, y, speed/1000, visibletime/1000, fadeout/1000, sound, font, center, r, g, b, loop)
+end
+mn.LuaSEXPs["lua-scroll-write-clear"].Action = function()
+  Scroll:Clear()
+end
+mn.LuaSEXPs["lua-scroll-write-set-iface-snd"].Action = function(idx)
+  Scroll:SetInterfaceSound(idx)
+end
+mn.LuaSEXPs["lua-scroll-write-set-game-snd"].Action = function(entry)
+  Scroll:SetGameSound(entry)
+end
 
 ]
 

--- a/ScrollWrite/data/tables/scrollwrite-sexp.tbm
+++ b/ScrollWrite/data/tables/scrollwrite-sexp.tbm
@@ -4,11 +4,11 @@ $Operator: lua-scroll-write
 $Category: Change
 $Subcategory: Scripted
 $Minimum Arguments: 1
-$Maximum Arguments: 12
+$Maximum Arguments: 13
 $Return Type: Nothing
 $Description: Writes a subtitle-esque string of text but one character at a time. Use this to spruce up your cutscenes!
 $Parameter:
-	+Description: Text to write
+	+Description: Text to write, or name of a message containing text
 	+Type: string
 $Parameter:
 	+Description: X coordinate to begin drawing at (based on percent of the screen width, 0-100). Default is 50
@@ -26,8 +26,8 @@ $Parameter:
 	+Description: Time it takes to fade everything out in milliseconds. Default is 0 ms.
 	+Type: number
 $Parameter:
-	+Description: Should the text drawing sound be played when drawing a new line? Defaults to true.
-	+Type: boolean	
+	+Description: Should the text drawing sound be played? Defaults to true.
+	+Type: boolean
 $Parameter:
 	+Description: Font to use for the text. Default is Font '1'.
 	+Type: string
@@ -43,12 +43,15 @@ $Parameter:
 $Parameter:
 	+Description: Text Color - Blue (0-255) Defaults to 255.
 	+Type: number
+$Parameter:
+	+Description: Should the text drawing sound be a continuous loop? If so, the sound is looped for as long as the text is scrolled. Defaults to false. Note: Only game sounds (not interface sounds) can be looped.
+	+Type: boolean
 
 $Operator: lua-scroll-write-file
 $Category: Change
 $Subcategory: Scripted
 $Minimum Arguments: 1
-$Maximum Arguments: 12
+$Maximum Arguments: 13
 $Return Type: Nothing
 $Description: Writes a subtitle-esque wall of text from a file but one character at a time. Use this to really spruce up your cutscenes! File must be a '.txt' in the fiction directory. Use '\n' for line breaks in the text file.
 $Parameter:
@@ -70,8 +73,8 @@ $Parameter:
 	+Description: Time it takes to fade everything out in milliseconds. Default is 0 ms.
 	+Type: number
 $Parameter:
-	+Description: Should the text drawing sound be played when drawing a new line? Defaults to true.
-	+Type: boolean	
+	+Description: Should the text drawing sound be played? Defaults to true.
+	+Type: boolean
 $Parameter:
 	+Description: Font to use for the text. Default is Font '1'.
 	+Type: string
@@ -87,6 +90,9 @@ $Parameter:
 $Parameter:
 	+Description: Text Color - Blue (0-255) Defaults to 255.
 	+Type: number
+$Parameter:
+	+Description: Should the text drawing sound be a continuous loop? If so, the sound is looped for as long as the text is scrolled. Defaults to false. Note: Only game sounds (not interface sounds) can be looped.
+	+Type: boolean
 
 $Operator: lua-scroll-write-clear
 $Category: Change
@@ -96,5 +102,29 @@ $Maximum Arguments: 0
 $Return Type: Nothing
 $Description: Clears all lines!
 
+$Operator: lua-scroll-write-set-iface-snd
+$Category: Change
+$Subcategory: Scripted
+$Minimum Arguments: 1
+$Maximum Arguments: 1
+$Return Type: Nothing
+$Description: Sets the interface sound to be played during the scroll write if the sound does not loop.
+$Parameter:
+	+Description: Index into the Interface Sounds section
+	+Type: number
+
+$Operator: lua-scroll-write-set-game-snd
+$Category: Change
+$Subcategory: Scripted
+$Minimum Arguments: 1
+$Maximum Arguments: 1
+$Return Type: Nothing
+$Description: Sets the game sound to be played during the scroll write if the sound loops.
+$Parameter:
+	+Description: A sound entry in the Game Sounds section
+;;FSO 20.1.0;; 	+Type: soundentry
+;;FSO 20.1.0;; !*
+	+Type: string
+;;FSO 20.1.0;; *!
 
 #End


### PR DESCRIPTION
This adds an option to the sound handling so that an in-mission looping sound is played for as long as the text is scrolling, and then stops when the text finishes scrolling.  Right now beep_5.wav is used as a placeholder sound effect; textdraw.wav could also be used, but it would have to be copied into the in-mission sound section in sounds.tbl.

Also adds an important detail to sexp help, removes trailing whitespace in the script, and fixes tab-indentation.

(Unfortunately the whitespace changes in `Scroll:Draw` make it appear that there are more changes than there really are.  The main non-whitespace changes are the addition of the `line.Handle` management and the removal of the `finalString` variable.)

This corresponds to the old PR 3:
https://github.com/AxemP/AxemFS2Scripts/pull/3