### PR TITLE
fix some sexp help documentation

### DIFF
--- a/AxMiscFunctions/data/tables/misc-sc-functions-sct.tbm
+++ b/AxMiscFunctions/data/tables/misc-sc-functions-sct.tbm
@@ -144,7 +144,7 @@ end
 
 mn.LuaSEXPs["lua-unlockdown"].Action = UnLockdownSEXP
 
-function Targettable(name)
+function Targetable(name)
 
 local isplayer = "false"
 
@@ -160,7 +160,7 @@ mn.runSEXP("( friendly-stealth-visible !" .. name .. "! )")
 
 end
 
-function UnTargettable(name)
+function UnTargetable(name)
 
 local isplayer = "false"
 
@@ -181,7 +181,7 @@ mn.LuaSEXPs["lua-set-targetable"].Action = function(...)
 	for _, data in ipairs(arg) do
 		local ship = data[1]
 		if ship:isValid() then
-			Targettable(ship.Name)
+			Targetable(ship.Name)
 		end
 	end
 
@@ -192,7 +192,7 @@ mn.LuaSEXPs["lua-set-untargetable"].Action = function(...)
 	for _, data in ipairs(arg) do
 		local ship = data[1]
 		if ship:isValid() then
-			UnTargettable(ship.Name)
+			UnTargetable(ship.Name)
 		end
 	end
 

--- a/AxMiscFunctions/data/tables/misc-sc-functions-sexp.tbm
+++ b/AxMiscFunctions/data/tables/misc-sc-functions-sexp.tbm
@@ -67,7 +67,7 @@ $Category: Change
 $Subcategory: Scripted
 $Minimum Arguments: 1
 $Return Type: Nothing
-$Description: Clears any flag that may prevent a ship to be targetted. (Invisible, stealthy, friendly-stealthy)
+$Description: Clears any flag that may prevent a ship to be targeted. (Invisible, stealthy, friendly-stealthy)
 $Repeat
 $Parameter:
 	+Description: Ships to become targetable
@@ -78,7 +78,7 @@ $Category: Change
 $Subcategory: Scripted
 $Minimum Arguments: 1
 $Return Type: Nothing
-$Description: Sets any flag that causes a ship to be targetted. (Invisible, stealthy, friendly-stealthy)
+$Description: Sets any flag that causes a ship to be targeted. (Invisible, stealthy, friendly-stealthy)
 $Repeat
 $Parameter:
 	+Description: Ships to become untargetable

--- a/IMJumpMultiSEXPs/readme.md
+++ b/IMJumpMultiSEXPs/readme.md
@@ -1,6 +1,6 @@
 
 # In Mission Jump Multi SEXPs
-These sexps are for doing in-mission jumps for one or more ships simultaneously. For player ships, they will perform all the associated effects for a jump including the warp effect and the subspace tunnel. For non player ships, they will perform warp outs, move the ships far away and set them as untargettable, and then return them at the appropriate time with a warp effect.
+These sexps are for doing in-mission jumps for one or more ships simultaneously. For player ships, they will perform all the associated effects for a jump including the warp effect and the subspace tunnel. For non player ships, they will perform warp outs, move the ships far away and set them as untargetable, and then return them at the appropriate time with a warp effect.
 
 You can jump multiple ships with a single sexp and they will be placed a set distance apart from each other at the target waypoint upon emerging from subspace.
 

--- a/MarkBox/data/tables/markbox-sexp.tbm
+++ b/MarkBox/data/tables/markbox-sexp.tbm
@@ -6,7 +6,7 @@ $Subcategory: Scripted
 $Minimum Arguments: 2
 ; No maximum arguments means that it accepts a variable number of arguments
 $Return Type: Nothing
-$Description: Highlights a ship to draw player attention to it. Text will be displayed by the ship when targetted.
+$Description: Highlights a ship to draw player attention to it. Text will be displayed by the ship when targeted.
 $Parameter:
 	+Description: Text to display
 	+Type: string
@@ -21,7 +21,7 @@ $Subcategory: Scripted
 $Minimum Arguments: 2
 ; No maximum arguments means that it accepts a variable number of arguments
 $Return Type: Nothing
-$Description: Highlights all ships in a wing to draw player attention to them. Text will be displayed by a ship when targetted.
+$Description: Highlights all ships in a wing to draw player attention to them. Text will be displayed by a ship when targeted.
 $Parameter:
 	+Description: Text to display
 	+Type: string
@@ -36,7 +36,7 @@ $Subcategory: Scripted
 $Minimum Arguments: 3
 ; No maximum arguments means that it accepts a variable number of arguments
 $Return Type: Nothing
-$Description: Highlights subsystems on a ship to assist the player in targetting specific subsystems. Text will be displayed by the subsystem when targetted.
+$Description: Highlights subsystems on a ship to assist the player in targeting specific subsystems. Text will be displayed by the subsystem when targeted.
 $Parameter:
 	+Description: Ship that has the subsystem to highlight
 	+Type: Ship
@@ -54,7 +54,7 @@ $Subcategory: Scripted
 $Minimum Arguments: 1
 $Maximum Arguments: 2
 $Return Type: Nothing
-$Description: Highlights weapons to help player identify important targets. Text will be displayed by the weapon when targetted. You can also specify a ship to tie distance calculations with the "lua-get-weapon-distance" sexp. The ship is pre-defined here for consideration of how much computing time calculating distances for tons of weapons can have on your poor CPU.
+$Description: Highlights weapons to help player identify important targets. Text will be displayed by the weapon when targeted. You can also specify a ship to tie distance calculations with the "lua-get-weapon-distance" sexp. The ship is pre-defined here for consideration of how much computing time calculating distances for tons of weapons can have on your poor CPU.
 $Parameter:
 	+Description: Weapon to highlight
 	+Type: string

--- a/MarkBox/readme.md
+++ b/MarkBox/readme.md
@@ -1,5 +1,5 @@
 # Mark Box
 
-This script will allow the mission designer to highlight certain ships, wings and subsystems. This script does not do targetting, only highlighting. For ships and wings, brackets will be drawn around the ships at all times. An optional text string will be drawn over a ship if it has been targetted. For subsystems, brackets will only be drawn if the parent ship is targetted. A simple health bar is also drawn next to the subsystem.
+This script will allow the mission designer to highlight certain ships, wings and subsystems. This script does not do targeting, only highlighting. For ships and wings, brackets will be drawn around the ships at all times. An optional text string will be drawn over a ship if it has been targeted. For subsystems, brackets will only be drawn if the parent ship is targeted. A simple health bar is also drawn next to the subsystem.
 
 A sample mission is included

--- a/PromptBox/data/tables/proBox-sexp.tbm
+++ b/PromptBox/data/tables/proBox-sexp.tbm
@@ -67,7 +67,7 @@ $Subcategory: Player
 $Minimum Arguments: 1
 $Maximum Arguments: 1
 $Return Type: number
-$Description: Highlights all ships in a wing to draw player attention to them. Text will be displayed by a ship when targetted. This will return 0 when uninitialized or waiting for a response, or 1-5 based on the last response.
+$Description: This will return 0 when uninitialized or waiting for a response, or 1-5 based on the last response.
 $Parameter:
 	+Description: Prompt Reference to use
 	+Type: string

--- a/TurretHotkey/readme.md
+++ b/TurretHotkey/readme.md
@@ -1,3 +1,3 @@
 # Turret Hotkey
 
-A simple script that allows a hotkey targetting functionality work for subsystems. Works pretty well with the MarkBox script!
+A simple script that allows a hotkey targeting functionality work for subsystems. Works pretty well with the MarkBox script!


### PR DESCRIPTION
Fix the spelling of "targeted", "targeting", etc.  Also remove the unintentionally misplaced text from `lua-get-prompt-response`.

This is a superset of the old PR 8:
https://github.com/AxemP/AxemFS2Scripts/pull/8