### PR TITLE
fix SaveLoad for an obscure edge case

### DIFF
--- a/SaveLoadX/data/tables/saveload2-sct.tbm
+++ b/SaveLoadX/data/tables/saveload2-sct.tbm
@@ -752,7 +752,7 @@ function SaveState:ApplyParseData(ship,data)
 			for i, pbank in ipairs(data.Subsystems[i].PBanks) do
 				ba.print("         Bank: " .. i .. "\n")
 				if subsys.PrimaryBanks[i] then
-					subsys.PrimaryBanks[i].Class = tb.WeaponClasses[pbank.Class]
+					subsys.PrimaryBanks[i] = tb.WeaponClasses[pbank.Class]
 					ba.print("         Class: " .. pbank.Class .. "\n")
 					if pbank.AmmoLeft then subsys.PrimaryAmmo[i] = self:GetAmmo(pbank.AmmoLeft,data.Name) end
 				end
@@ -764,7 +764,7 @@ function SaveState:ApplyParseData(ship,data)
 			for i, sbank in ipairs(data.Subsystems[i].SBanks) do
 				ba.print("         Bank: " .. i .. "\n")
 				if subsys.SecondaryBanks[i] then
-					subsys.SecondaryBanks[i].Class = tb.WeaponClasses[sbank.Class]
+					subsys.SecondaryBanks[i] = tb.WeaponClasses[sbank.Class]
 					ba.print("         Class: " .. sbank.Class .. "\n")
 					if sbank.AmmoLeft then subsys.SecondaryAmmo[i] = self:GetAmmo(sbank.AmmoLeft,data.Name) end
 				end


### PR DESCRIPTION
If you have a ship that hasn't arrived yet, and that ship has a turret with a changed weapon on it, then restoring a checkpoint will cause a crash. This is because subsystems on parse objects use the weapon class directly, not weaponbanktype. This PR fixes the crash.

This corresponds to the old PR 6:
AxemP/AxemFS2Scripts#6