### PR TITLE
add option to keep HUD hidden when exiting visual novel scene

### DIFF
--- a/AxBase/data/tables/parsecfg-sct.tbm
+++ b/AxBase/data/tables/parsecfg-sct.tbm
@@ -172,12 +172,26 @@ function axemParse:Write(t, filename, path)
 
 end
 
-function axemParse:Validate(reference, input, expectedtype, optional)
+function axemParse:Validate(reference, input, expectedtypes, optional)
+
+	if type(expectedtypes) == "string" then
+		expectedtypes = { expectedtypes }
+	end
 
 	if not input and optional then
 		return true
-	elseif type(input) ~= expectedtype then
-		ba.warning("Invalid entry for " .. reference .. ", expected a " .. expectedtype)
+	else
+		for i, v in ipairs(expectedtypes) do
+			if type(input) == v then
+				return true
+			end
+		end
+
+		local s = expectedtypes[1]
+		for i = 2, #expectedtypes do
+			s = s .. ", " .. expectedtypes[i]
+		end
+		ba.warning("Invalid entry for " .. reference .. ", expected one of [" .. s .. "]")
 	end
 
 end

--- a/vn/data/tables/vs3-sct.tbm
+++ b/vn/data/tables/vs3-sct.tbm
@@ -676,7 +676,14 @@ function VS3:Action(t)
 	
 	local action = string.lower(t[2])
 	
-	axemParse:Validate("line " .. self.Scene.Line .. ": argument 1", t[3], "number", true)
+	local t3types
+	if action == "lockdown" or action == "endscene" then
+		t3types = {"number", "string"}
+	else
+		t3types = "number"
+	end
+	
+	axemParse:Validate("line " .. self.Scene.Line .. ": argument 1", t[3], t3types, true)
 	axemParse:Validate("line " .. self.Scene.Line .. ": argument 2", t[4], "number", true)
 	axemParse:Validate("line " .. self.Scene.Line .. ": argument 3", t[5], "number", true)
 	axemParse:Validate("line " .. self.Scene.Line .. ": argument 4", t[6], "number", true)
@@ -733,7 +740,7 @@ function VS3:Action(t)
 		if not VS3.StayInGame then
 			io.setCursorHidden(true)
 		end
-		VS3:Exit(true)		--The true will keep variables alive
+		VS3:Exit(true, nil, t[3] and string.lower(t[3])=="keephudhidden")		--keepvars=true, initflag=nil
 	elseif action == "hidecursor" then
 		io.setCursorHidden(true)
 		VS3.ShowCursor = false
@@ -3459,7 +3466,7 @@ function VS3:ExpireStandard()
 	end
 end
 
-function VS3:Exit(keepvars, initflag)
+function VS3:Exit(keepvars, initflag, keephudhidden)
 
 	if self.Enabled then
 		ba.print("Exiting Visual Novel Script...\n")
@@ -3518,7 +3525,7 @@ function VS3:Exit(keepvars, initflag)
 		mn.runSEXP("(adjust-audio-volume !Music! 0)")
 		mn.runSEXP("(adjust-audio-volume !Music! 100 1000)")
 		mn.runSEXP("(pause-sound-from-file (false))")
-	else
+	elseif not keephudhidden then
 		mn.runSEXP("(hud-disable 0)")
 		if not initflag then
 			mn.runSEXP("(enable-builtin-messages)")


### PR DESCRIPTION
The visual novel script usually re-enables the HUD when a scene ends, but the KeepHUDHidden option now allows that to be skipped.

This also requires adding an extension to the validator to accept multiple data types.  However this extension is needed anyway as a bugfix, since the 'lockdown' action can accept a string as well as a number.