### PR TITLE
sync some upgrades from Scroll's version of the scroll script

### DIFF
--- a/ScrollWrite/data/tables/scrollwrite-sct.tbm
+++ b/ScrollWrite/data/tables/scrollwrite-sct.tbm
@@ -12,12 +12,35 @@ function Scroll:Init()
 	self.InterfaceSound = 20
 	self.GameSound = ad.getSoundentry(10)
 
+	self.UseConfig = false
+	self.BaseWidth = nil
+	self.BaseHeight = nil
+	self.StandardWidth = nil
+	self.StandardHeight = nil
+	self.StandardFont = nil
+
 end
 
 function Scroll:Clear()
 
 	self.Enabled = false
 	self.Lines = {}
+
+end
+
+function Scroll:Configure(gauge_name, standard_width, standard_height)
+
+	local gauge = hu.getHUDGaugeHandle(gauge_name)
+	if not gauge then
+		ba.warning("ScrollWrite: HUD gauge '" .. tostring(gauge_name) .. "' not found!")
+		return
+	end
+
+	self.BaseWidth, self.BaseHeight = gauge:getBaseResolution()
+	self.StandardWidth = standard_width or 1024
+	self.StandardHeight = standard_height or 768
+	self.StandardFont = gauge:getFont()
+	self.UseConfig = true
 
 end
 
@@ -56,16 +79,32 @@ function Scroll:Write(text, x, y, speed, visibletime, fadeout, sound, font, cent
 		t.Text = text
 	end
 
+	if self.UseConfig then
+		t.X = x or (self.StandardWidth / 2)
+		t.X = t.X * self.BaseWidth / self.StandardWidth
+		t.Y = y or (self.StandardHeight / 2)
+		t.Y = t.Y * self.BaseHeight / self.StandardHeight
+	else
 	t.X = x or 50
 	t.X = gr.getScreenWidth() * (t.X/100)
 	t.Y = y or 50
 	t.Y = gr.getScreenHeight() * (t.Y/100)
+	end
+
 	t.Speed = speed or 0.03
 	t.SoundDuration = #t.Text * t.Speed
 	t.Timestamp = mn.getMissionTime()
 	t.Time = visibletime or 5
 	t.FadeOut = fadeout or 0
-	t.Font = font or 1
+
+	if font and font:lower() ~= "default" then
+		t.Font = gr.Fonts[font]
+	elseif self.UseConfig then
+		t.Font = self.StandardFont
+	else
+		t.Font = gr.Fonts[1]
+	end
+
 	if sound == false then
 		t.Sound = false
 	else
@@ -91,12 +130,17 @@ end
 function Scroll:Draw()
 
 	local mTime = mn.getMissionTime()
+	local savedFont
 
-	if #self.Lines > 0 then
 		local numLines = #self.Lines
+	if numLines > 0 then
+		if self.UseConfig then
+			gr.setScreenScale(self.BaseWidth, self.BaseHeight)
+		end
+
 		for i = 1, numLines do
-			if self.Lines[i] then
 				local line = self.Lines[i]
+			if line then
 				if mTime < (line.Timestamp + line.Time + line.FadeOut) then
 					if line.Sound then
 						if line.Loop then
@@ -106,20 +150,24 @@ function Scroll:Draw()
 						end
 						line.Sound = nil
 					end
+
 					local toDraw = (mTime - line.Timestamp) / line.Speed
 					if toDraw > 0 then
 						local displayString = line.Text:sub(1, toDraw)
 						local lastChar = line.Text:sub(-1)
 						local x, y = line.X, line.Y
 
-						gr.CurrentFont = gr.Fonts[line.Font]
+						if not savedFont then
+							savedFont = gr.CurrentFont
+						end
+						gr.CurrentFont = line.Font
 
 						if line.Handle and mTime > (line.Timestamp + line.SoundDuration) then
 							line.Handle:stop()
 							line.Handle = nil
 						end
 						if mTime > (line.Timestamp + line.Time) then
-							local t = mn.getMissionTime() - (line.Timestamp + line.Time)
+							local t = mTime - (line.Timestamp + line.Time)
 							line.Alpha = self:Ease(t,255,-255,line.FadeOut)
 						end
 
@@ -132,19 +180,31 @@ function Scroll:Draw()
 						gr.setColor(line.Color[1], line.Color[2], line.Color[3], line.Alpha)
 
 						if line.Center then
-							x = line.X - (gr.getStringWidth(line.Text)/2)
+							x = x - (gr.getStringWidth(line.Text)/2)
 						end
 
+						if self.UseConfig then
+							gr.drawStringResized(GR_RESIZE_FULL,displayString,x,y)
+						else
 						gr.drawString(displayString,x,y)
 					end
+				end
 				end
 			else
 				table.remove(self.Lines,i)
 				numLines = numLines - 1
 
-				if numLines == 0 then self.Enabled = false end
-
+				if numLines == 0 then
+					self.Enabled = false
+				end
 			end
+		end
+
+		if self.UseConfig then
+			gr.resetScreenScale()
+		end
+		if savedFont then
+			gr.CurrentFont = savedFont
 		end
 	end
 
@@ -173,6 +233,9 @@ function Scroll:SetGameSound(entry)
 	end
 end
 
+mn.LuaSEXPs["lua-scroll-write-configure"].Action = function(gauge_name, standard_width, standard_height)
+  Scroll:Configure(gauge_name, standard_width, standard_height)
+end
 mn.LuaSEXPs["lua-scroll-write"].Action = function(text, x, y, speed, visibletime, fadeout, sound, font, center, r, g, b, loop)
   Scroll:Write(text, x, y, speed/1000, visibletime/1000, fadeout/1000, sound, font, center, r, g, b, loop)
 end
@@ -191,12 +254,12 @@ end
 
 ]
 
-$State: GS_STATE_GAME_PLAY
-$On Gameplay Start: 
+$On Mission Start: 
 [
 	Scroll:Init()
 ]
 
+$State: GS_STATE_GAME_PLAY
 $On Frame:
 [
 	if Scroll.Enabled then

--- a/ScrollWrite/data/tables/scrollwrite-sexp.tbm
+++ b/ScrollWrite/data/tables/scrollwrite-sexp.tbm
@@ -1,8 +1,25 @@
 #Lua SEXPs
 
+$Operator: lua-scroll-write-configure
+$Category: Change
+$Subcategory: ScrollWrite
+$Minimum Arguments: 1
+$Maximum Arguments: 3
+$Return Type: Nothing
+$Description: Sets font and screen information based on the specified HUD gauge.  If this is called, it will set a new default font to be used in lua-scroll-write and lua-scroll-write-file, and it will change the coordinates to be specified in pixels, not percentages.
+$Parameter:
+	+Description: HUD gauge
+	+Type: string
+$Parameter:
+	+Description: Width of the screen used to position the scroll text (optional$semicolon defaults to 1024)
+	+Type: number
+$Parameter:
+	+Description: Height of the screen used to position the scroll text (optional$semicolon defaults to 768)
+	+Type: number
+
 $Operator: lua-scroll-write
 $Category: Change
-$Subcategory: Scripted
+$Subcategory: ScrollWrite
 $Minimum Arguments: 1
 $Maximum Arguments: 13
 $Return Type: Nothing
@@ -11,10 +28,10 @@ $Parameter:
 	+Description: Text to write, or name of a message containing text
 	+Type: string
 $Parameter:
-	+Description: X coordinate to begin drawing at (based on percent of the screen width, 0-100). Default is 50
+	+Description: X coordinate to begin drawing at (based on percent of the screen width, 0-100, or pixels if lua-scroll-write-configure is called). Default is 50%
 	+Type: number
 $Parameter:
-	+Description: Y coordinate to begin drawing at (based on percent of the screen height, 0-100). Default is 50
+	+Description: Y coordinate to begin drawing at (based on percent of the screen height, 0-100, or pixels if lua-scroll-write-configure is called). Default is 50%
 	+Type: number
 $Parameter:
 	+Description: Text speed, the number of milliseconds between each character. Default is 30.
@@ -29,7 +46,7 @@ $Parameter:
 	+Description: Should the text drawing sound be played? Defaults to true.
 	+Type: boolean
 $Parameter:
-	+Description: Font to use for the text. Default is Font '1'.
+	+Description: Font to use for the text. Default (if unspecified or 'default') is Font '1', or the HUD gauge font if lua-scroll-write-configure is called.
 	+Type: string
 $Parameter:
 	+Description: Should text be centered? Defaults to true.
@@ -49,7 +66,7 @@ $Parameter:
 
 $Operator: lua-scroll-write-file
 $Category: Change
-$Subcategory: Scripted
+$Subcategory: ScrollWrite
 $Minimum Arguments: 1
 $Maximum Arguments: 13
 $Return Type: Nothing
@@ -58,10 +75,10 @@ $Parameter:
 	+Description: File to write (must be present in the ficion directory!)
 	+Type: string
 $Parameter:
-	+Description: X coordinate to begin drawing at (based on percent of the screen width, 0-100). Default is 50
+	+Description: X coordinate to begin drawing at (based on percent of the screen width, 0-100, or pixels if lua-scroll-write-configure is called). Default is 50%
 	+Type: number
 $Parameter:
-	+Description: Y coordinate to begin drawing at (based on percent of the screen height, 0-100). Default is 50
+	+Description: Y coordinate to begin drawing at (based on percent of the screen height, 0-100, or pixels if lua-scroll-write-configure is called). Default is 50%
 	+Type: number
 $Parameter:
 	+Description: Text speed, the number of milliseconds between each character. Default is 30.
@@ -76,7 +93,7 @@ $Parameter:
 	+Description: Should the text drawing sound be played? Defaults to true.
 	+Type: boolean
 $Parameter:
-	+Description: Font to use for the text. Default is Font '1'.
+	+Description: Font to use for the text. Default (if unspecified or 'default') is Font '1', or the HUD gauge font if lua-scroll-write-configure is called.
 	+Type: string
 $Parameter:
 	+Description: Should text be centered? Defaults to true.
@@ -96,7 +113,7 @@ $Parameter:
 
 $Operator: lua-scroll-write-clear
 $Category: Change
-$Subcategory: Scripted
+$Subcategory: ScrollWrite
 $Minimum Arguments: 0
 $Maximum Arguments: 0
 $Return Type: Nothing
@@ -104,7 +121,7 @@ $Description: Clears all lines!
 
 $Operator: lua-scroll-write-set-iface-snd
 $Category: Change
-$Subcategory: Scripted
+$Subcategory: ScrollWrite
 $Minimum Arguments: 1
 $Maximum Arguments: 1
 $Return Type: Nothing
@@ -115,7 +132,7 @@ $Parameter:
 
 $Operator: lua-scroll-write-set-game-snd
 $Category: Change
-$Subcategory: Scripted
+$Subcategory: ScrollWrite
 $Minimum Arguments: 1
 $Maximum Arguments: 1
 $Return Type: Nothing

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ This is a collection of user-made scripts for the [FreeSpace Open engine](https:
 |RadarIcon|Adds configurable icons for ships and weapons onto the HUD, making it easier to keep an overview over the battlefield|20.0|AxBase|Lafiel|
 |RadarIcon_Generic|Optional prebuilt configuration using generic icons for RadarIcon, instead of the default per-ship-class icons.|20.0|AxBase, RadarIcon|Lafiel, JadedDragoon|
 |SaveLoadX|A streamlined checkpoint and savestate system|21.0|AxBase|Axem|
-|ScrollWrite|Draws text on-screen letter by letter, for cutscenes mostly|21.0|AxBase|Axem|
+|ScrollWrite|Draws text on-screen letter by letter, for cutscenes mostly|22.2|AxBase|Axem|
 |Send Message Alt SEXPS|More powerful versions of the built-in send-message SEXPs|22.0||Naomimyselfandi|
 |SpawnSystem|A system for infinite auto-spawning of ships|21.0|AxBase|Axem|
 |Speedlines|Draws Anime-esque Speedlines onto the screen|21.0|AxBase|Axem|


### PR DESCRIPTION
1. Add `lua-scroll-write-configure` SEXP to specify font from a HUD gauge and to change the coordinate system to pixels - useful for making text appear properly at different resolutions
2. Change category from Scripted to ScrollWrite
3. Move the state condition to a more relevant hook