### PR TITLE
sync some upgrades from Scroll's version of the markbox script

### DIFF
--- a/MarkBox/data/tables/markbox-sct.tbm
+++ b/MarkBox/data/tables/markbox-sct.tbm
@@ -11,14 +11,23 @@ function MarkBox:Init()
 	self.List = {}
 	self.WeaponList = {}
 
-	self.DefaultFont = gr.Fonts[1]
-	self.MarkFont = gr.Fonts[3]
+	local gauge = hu.getHUDGaugeHandle("Target Monitor")
+	self.FONT = gauge:getFont()
+	self.BASE_WIDTH, self.BASE_HEIGHT = gauge:getBaseResolution()
+	self.RESCALE_X = self.BASE_WIDTH / gr.getScreenWidth()
+	self.RESCALE_Y = self.BASE_HEIGHT / gr.getScreenHeight()
+
 	self.DrawSubsysDiagonals = true
 	self.DrawSubsysHealth = true
 
 	self.NextDistCheck = 0
 	self.DistCheckInterval = 1
 
+end
+
+-- Scale screen coordinates back to base coordinates so we can rescale them again
+function MarkBox:RescaleCoords(x, y)
+	return x * self.RESCALE_X, y * self.RESCALE_Y
 end
 
 function MarkBox:AddSubsys(ship, text, ...)
@@ -333,7 +342,6 @@ function MarkBox:DrawSubsystemBracket(subsys, data)
 	local player = hv.Player
 	
 	--gr.setColor(255,255,255,255)
-	--gr.CurrentFont = self.DefaultFont
 	--gr.drawString("Target Data:",100,100)
 	--gr.drawString("Ship: " .. player.Target.Name)
 	--gr.drawString("Actual: " .. player.TargetSubsystem:getModelName())
@@ -385,8 +393,6 @@ function MarkBox:DrawSubsystemBracket(subsys, data)
 			gr.drawLine(nx2-1, ny2-1, nx2-lineLength, ny2)
 			gr.drawLine(nx2-1, ny2-1, nx2, ny2-lineLength)
 	
-			gr.CurrentFont = self.MarkFont
-	
 			if focus and self.DrawSubsysDiagonals then
 				gr.drawLine(x1, y1, nx1, ny1)
 				gr.drawLine(x1, y2, nx1, ny2)
@@ -396,7 +402,13 @@ function MarkBox:DrawSubsystemBracket(subsys, data)
 			end
 			
 			if data.Text then
-				gr.drawString(data.Text,nx2+5,ny2-20)
+				local savedFont = gr.CurrentFont
+				gr.CurrentFont = self.FONT
+				local xt, yt = self:RescaleCoords(nx2+5, ny2-20)
+				gr.setScreenScale(self.BASE_WIDTH, self.BASE_HEIGHT)
+				gr.drawStringResized(GR_RESIZE_FULL, data.Text, xt, yt)
+				gr.resetScreenScale()
+				gr.CurrentFont = savedFont
 			end
 
 			if self.DrawSubsysHealth and subsys.HitpointsMax > 0 then
@@ -432,12 +444,16 @@ function MarkBox:DrawShipBracket(ship, data)
 		gr.setLineWidth(1)
 	else
 		if data.Text then
-			gr.CurrentFont = self.MarkFont
 			local x1,y1,x2,y2 = gr.drawTargetingBrackets(ship, false)
 			if x1 and y1 then
-				gr.drawString(data.Text,x1-5,y1-16)
+				local savedFont = gr.CurrentFont
+				gr.CurrentFont = self.FONT
+				local xt, yt = self:RescaleCoords(x1-5, y1-16)
+				gr.setScreenScale(self.BASE_WIDTH, self.BASE_HEIGHT)
+				gr.drawStringResized(GR_RESIZE_FULL, data.Text, xt, yt)
+				gr.resetScreenScale()
+				gr.CurrentFont = savedFont
 			end
-			gr.CurrentFont = self.DefaultFont
 		end
 	end
 
@@ -531,17 +547,15 @@ mn.LuaSEXPs["lua-mark-weapon"].Action = function(weapon, ship) MarkBox:AddWeapon
 mn.LuaSEXPs["lua-count-weapon"].Action = function(weapon) return MarkBox:GetCountWeapon(weapon) end
 mn.LuaSEXPs["lua-get-weapon-distance"].Action = function(weapon) return MarkBox:GetMarkedWeaponDistance(weapon) end
 
+mn.LuaSEXPs["lua-mark-set-flags"].Action = function(subsys_diagonals, subsys_health)
+	MarkBox.DrawSubsysDiagonals = subsys_diagonals
+	MarkBox.DrawSubsysHealth = subsys_health
+end
 ]
 
-$State: GS_STATE_GAME_PLAY
-$On Gameplay Start:
+$On Mission Start:
 [
 	MarkBox:Init()
-]
-
-$On State End:
-[
-	MarkBox.Enabled = false
 ]
 
 $On Weapon Created:
@@ -558,6 +572,7 @@ $On Weapon Delete:
 	end
 ]
 
+$State: GS_STATE_GAME_PLAY
 $On HUD Draw:
 [
 	if MarkBox.Enabled and hu.HUDDrawn and not hu.HUDDisabledExceptMessages and (gr.hasViewmode(VM_INTERNAL) or gr.hasViewmode(VM_CHASE)) then

--- a/MarkBox/data/tables/markbox-sexp.tbm
+++ b/MarkBox/data/tables/markbox-sexp.tbm
@@ -2,7 +2,7 @@
 
 $Operator: lua-mark-ship
 $Category: Change
-$Subcategory: Scripted
+$Subcategory: Markbox
 $Minimum Arguments: 2
 ; No maximum arguments means that it accepts a variable number of arguments
 $Return Type: Nothing
@@ -17,7 +17,7 @@ $Parameter:
 
 $Operator: lua-mark-wing
 $Category: Change
-$Subcategory: Scripted
+$Subcategory: Markbox
 $Minimum Arguments: 2
 ; No maximum arguments means that it accepts a variable number of arguments
 $Return Type: Nothing
@@ -30,9 +30,23 @@ $Parameter:
 	+Description: Wing to highlight
 	+Type: string
 
+$Operator: lua-mark-set-flags
+$Category: Change
+$Subcategory: Markbox
+$Minimum Arguments: 2
+$Maximum Arguments: 2
+$Return Type: Nothing
+$Description: Sets global configuration options for marking things
+$Parameter:
+	+Description: Whether to draw diagonal lines on subsystems
+	+Type: boolean
+$Parameter:
+	+Description: Whether to draw subsystem health
+	+Type: boolean
+
 $Operator: lua-mark-subsystem
 $Category: Change
-$Subcategory: Scripted
+$Subcategory: Markbox
 $Minimum Arguments: 3
 ; No maximum arguments means that it accepts a variable number of arguments
 $Return Type: Nothing
@@ -50,7 +64,7 @@ $Parameter:
 	
 $Operator: lua-mark-weapon
 $Category: Change
-$Subcategory: Scripted
+$Subcategory: Markbox
 $Minimum Arguments: 1
 $Maximum Arguments: 2
 $Return Type: Nothing
@@ -64,7 +78,7 @@ $Parameter:
 	
 $Operator: lua-count-weapon
 $Category: Status
-$Subcategory: Mission
+$Subcategory: Markbox Status
 $Minimum Arguments: 1
 $Maximum Arguments: 1
 $Return Type: Number
@@ -75,7 +89,7 @@ $Parameter:
 	
 $Operator: lua-get-weapon-distance
 $Category: Status
-$Subcategory: Mission
+$Subcategory: Markbox Status
 $Minimum Arguments: 1
 $Maximum Arguments: 1
 $Return Type: Number
@@ -86,7 +100,7 @@ $Parameter:
 
 $Operator: lua-mark-clear-all
 $Category: Change
-$Subcategory: Scripted
+$Subcategory: Markbox
 $Minimum Arguments: 0
 $Maximum Arguments: 0
 $Return Type: Nothing
@@ -94,7 +108,7 @@ $Description: Clears *everything* from the mark box list (subsystems, ships, win
 
 $Operator: lua-mark-clear-ship
 $Category: Change
-$Subcategory: Scripted
+$Subcategory: Markbox
 $Minimum Arguments: 1
 ; No maximum arguments means that it accepts a variable number of arguments
 $Return Type: Nothing
@@ -106,7 +120,7 @@ $Parameter:
 	
 $Operator: lua-mark-clear-wing
 $Category: Change
-$Subcategory: Scripted
+$Subcategory: Markbox
 $Minimum Arguments: 1
 ; No maximum arguments means that it accepts a variable number of arguments
 $Return Type: Nothing
@@ -118,7 +132,7 @@ $Parameter:
 	
 $Operator: lua-mark-clear-subsys
 $Category: Change
-$Subcategory: Scripted
+$Subcategory: Markbox
 $Minimum Arguments: 2
 ; No maximum arguments means that it accepts a variable number of arguments
 $Return Type: Nothing

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ This is a collection of user-made scripts for the [FreeSpace Open engine](https:
 |Joystick-Mouse|adds an in-game button to toggle the mouse to act like a joystick.|22.0||wookieejedi
 |LafielsSEXPs|Some of Lafiels convenience SEXP, including turret information retrieval.|22.0||Lafiel|
 |Mainhall Notifications|Adds a system for custom popup messages displayed at the mainhall menu|22.0|AxBase, SCPUI|Naomimyselfandi|
-|MarkBox|Can draw target-like boxes around arbitary ships / wings|21.0|AxBase|Axem|
+|MarkBox|Can draw target-like boxes around arbitary ships / wings|22.2|AxBase|Axem|
 |Mission-Role-Gauge|Custom HUD gauge that FREDers can use to display information.|22.0||wookieejedi
 |Movements-SEXPs|Custom SEXPs to easily enable dynamic capital ship movements.|22.0||wookieejedi
 |PromptBox|A tool to prompt the player for decisions|21.0|AxBase|Axem|


### PR DESCRIPTION
1. Automatically configure markbox from the Target Monitor HUD gauge to match the font and coordinate system - useful for making text appear properly at different resolutions
2. Add `lua-mark-set-flags` SEXP to set whether certain markbox decorations should be drawn
3. Change category from Scripted to Markbox
4. A few tweaks