### PR TITLE
prevent weapons from firing after promptbox

### DIFF
--- a/AxBase/data/tables/axui-sct.tbm
+++ b/AxBase/data/tables/axui-sct.tbm
@@ -1056,7 +1056,7 @@ function AXUI:Draw()
 		--gr.drawRectangle(self.Region.x1,self.Region.y1,self.Region.x2,self.Region.y2)	--DEBUG For checking hotspots
 		
 			--Is this good for clicking?
-			if io.isMouseButtonDown(MOUSE_LEFT_BUTTON) and self.Clickable == true then
+			if self.Clickable == true and io.isMouseButtonDown(MOUSE_LEFT_BUTTON) then
 
 				if self.Color_C ~= nil then
 					color = self.Color_C

--- a/PromptBox/data/tables/proBox-sct.tbm
+++ b/PromptBox/data/tables/proBox-sct.tbm
@@ -422,7 +422,8 @@ function PromptBox:LockPlayer()
 			end
 			
 			self.Flags = {}
-						
+			
+			-- set some flags on the player ship to prevent things like aspect lock
 			for __,v in pairs(self.Actions) do
 				if not mn.evaluateSEXP("(are-ship-flags-set !" .. playerName .. "! !" .. v .. "!)") then
 					mn.runSEXP("(alter-ship-flag !" .. v .. "! ( true ) ( false ) !" .. playerName .. "!)")
@@ -430,6 +431,7 @@ function PromptBox:LockPlayer()
 				end
 			end
 			
+			-- indefinitely prevent any activation of the Communications or weapons firing controls
 			mn.runSEXP("(ignore-key !-1! !C! !Left Ctrl! !Spacebar!)")
 	
 	end
@@ -448,13 +450,15 @@ function PromptBox:UnlockPlayer()
 		if self.PlayerMouse then
 			io.MouseControlStatus = true
 		end
-					
+		
+		-- remove the flags added in LockPlayer
 		for __,v in pairs(self.Flags) do
 			mn.runSEXP("(alter-ship-flag !" .. v .. "! ( false ) ( false ) !" .. playerName .. "!)")
 		end
 		
 		self.Flags = {}
 		
+		-- allow the deactivated controls again
 		mn.runSEXP("(ignore-key !0! !C! !Left Ctrl! !Spacebar!)")
 	
 	end

--- a/PromptBox/data/tables/proBox-sct.tbm
+++ b/PromptBox/data/tables/proBox-sct.tbm
@@ -430,7 +430,7 @@ function PromptBox:LockPlayer()
 				end
 			end
 			
-			mn.runSEXP("(ignore-key !-1! !C!)")
+			mn.runSEXP("(ignore-key !-1! !C! !Left Ctrl! !Spacebar!)")
 	
 	end
 
@@ -455,7 +455,7 @@ function PromptBox:UnlockPlayer()
 		
 		self.Flags = {}
 		
-		mn.runSEXP("(ignore-key !0! !C!)")
+		mn.runSEXP("(ignore-key !0! !C! !Left Ctrl! !Spacebar!)")
 	
 	end
 


### PR DESCRIPTION
When ignoring controls, also ignore the primary and secondary weapons firing triggers.  This will prevent weapons from inadvertently firing due to the mouse click activating both the prompt and the firing control.

Also when drawing clickable buttons, check the Clickable flag first for a small improvement in efficiency.