### PR TITLE
change mn.Ships and mn.Weapons iteration to use iterators

### DIFF
--- a/AxMiscFunctions/data/tables/getclosest-sct.tbm
+++ b/AxMiscFunctions/data/tables/getclosest-sct.tbm
@@ -7,14 +7,11 @@ mn.LuaSEXPs["lua-get-closest-from-team"].Action = function(origin, targetTeam, t
 
 	if origin:isValid() and targetVariable:isValid() then
 	
-		local numShips = #mn.Ships
 		local bestShip
 		local bestDistance = 99999999
 		
-		for i=1, numShips do
+		for thisShip in mn.getShipList() do
 		
-			local thisShip = mn.Ships[i]
-			
 			if thisShip:isValid() and (thisShip ~= origin) and (thisShip.Team.Name == targetTeam) then
 			
 				local thisDistance = origin.Position:getDistance(thisShip.Position)

--- a/SaveLoadX/data/tables/saveload2-sct.tbm
+++ b/SaveLoadX/data/tables/saveload2-sct.tbm
@@ -64,10 +64,8 @@ function SaveState:GetAllCurrentShips()
 	ba.print("SAVELOAD: Getting ships present at start...\n")
 
 	local t = {}
-	local numShips = #mn.Ships
 	
-	for i=1, numShips do
-		local thisShip = mn.Ships[i]
+	for thisShip in mn.getShipList() do
 		if thisShip and thisShip:isValid() then
 			t[#t+1] = thisShip.Name
 			ba.print("SAVELOAD: Found " .. thisShip.Name .. ", adding to Ship List\n")
@@ -445,10 +443,7 @@ function SaveState:LoadAll(index)
 	
 	--Apply saved data to ships that are present
 	
-	local numShips = #mn.Ships
-	
-	for i=1, numShips do
-		local thisShip = mn.Ships[i]
+	for thisShip in mn.getShipList() do
 		if thisShip and thisShip:isValid() then
 			local thisShipName = thisShip.Name
 			local data = thisloadeddata[thisShipName]

--- a/radaricon/data/tables/radaricon-sct.tbm
+++ b/radaricon/data/tables/radaricon-sct.tbm
@@ -347,14 +347,12 @@ function RadarIcon:MaybeDeleteWeapon(weapon)
 end
 
 function RadarIcon:LoadShips()
-	local number = #mn.Ships
-	for i = 1, number, 1 do
-		RadarIcon:MaybeAddShip(mn.Ships[i])
+	for thisShip in mn.getShipList() do
+		RadarIcon:MaybeAddShip(thisShip)
 	end
-	number = #mn.Weapons
-	for i = 1, number, 1 do
-		local team = mn.Weapons[i].Team
-		local parent = mn.Weapons[i].Parent
+	for thisMissile in mn.getMissileList() do
+		local team = thisMissile.Team
+		local parent = thisMissile.Parent
 		while parent ~= nil and parent:getBreedName() ~= "Ship" do
 			if parent:getSignature() == parent.Parent:getSignature() then
 				break
@@ -372,7 +370,7 @@ function RadarIcon:LoadShips()
 				species = parent.Class.Species
 			end
 			
-			RadarIcon:MaybeAddWeapon(mn.Weapons[i], team, RadarIcon:GetTeamColor(mn.Weapons[i], team, species))
+			RadarIcon:MaybeAddWeapon(thisMissile, team, RadarIcon:GetTeamColor(thisMissile, team, species))
 		end
 	end
 end

--- a/vn/data/tables/vs3-sct.tbm
+++ b/vn/data/tables/vs3-sct.tbm
@@ -3575,8 +3575,8 @@ function Freeze()
 		SLAF = {} --SEXP Library Axem Freeze
 		SLAFActions = {"immobile", "invulnerable", "protect-ship", "afterburners-locked", "primaries-locked", "secondaries-locked"}
 
-		for i = 1, #mn.Ships do
-			local name = mn.Ships[i].Name
+		for thisShip in mn.getShipList() do
+			local name = thisShip.Name
 			local t = {}
 			
 			for __, action in ipairs(SLAFActions) do


### PR DESCRIPTION
This improves list iteration performance from O(n^2) to O(n).  It also fixes a bug in SaveLoadX that was revealed in builds from 20230104 onward: destroying ships while iterating over the ship list will invalidate the index, so it is important to use the `getShipList()` iterator.