### PR TITLE
add the LOADSCENE action

### DIFF
--- a/vn/README.md
+++ b/vn/README.md
@@ -29,7 +29,7 @@ The config for the Visual Novel script is done through the file vs3.cfg. In rare
 }
 ```
 A note on the shorthand for JSON that will be used from now on:
-The statement "``x.y.z`` is set to w" is essentially equivalent to the following JSON (with w being it's respective data type obviously):
+The statement "``x.y.z`` is set to w" is essentially equivalent to the following JSON (with w being its respective data type obviously):
 ```json
 {
 	"x": {
@@ -60,17 +60,17 @@ Key | Value | Optional
 -|-|-
 ``Graphics.<name>.MinRes`` | The minimally required horizontal screen resolution for this configuration
 ``Graphics.<name>.Text.Title.Color[]`` | The R, G, B, A values of the name of the currently speaking character (called title, color can be overridden by the specific character)
-``Graphics.<name>.Text.Title.Offset.x`` | The horizontal distance in pixels the title is offset from the top left of the message box (not it's bounding box)
-``Graphics.<name>.Text.Title.Offset.y`` | The vertical distance in pixels the title is offset from the top left of the message box (not it's bounding box)
+``Graphics.<name>.Text.Title.Offset.x`` | The horizontal distance in pixels the title is offset from the top left of the message box (not its bounding box)
+``Graphics.<name>.Text.Title.Offset.y`` | The vertical distance in pixels the title is offset from the top left of the message box (not its bounding box)
 ``Graphics.<name>.Text.Title.Font`` | The name of the font (in fonts.tbl) to use for the title
 ``Graphics.<name>.Text.Message.Color[]`` | The R, G, B, A values of the text for dialog
-``Graphics.<name>.Text.Message.Offset.x`` | The horizontal distance in pixels the dialog is offset from the top left of the message box (not it's bounding box)
-``Graphics.<name>.Text.Message.Offset.y`` | The vertical distance in pixels the dialog is offset from the top left of the message box (not it's bounding box)
+``Graphics.<name>.Text.Message.Offset.x`` | The horizontal distance in pixels the dialog is offset from the top left of the message box (not its bounding box)
+``Graphics.<name>.Text.Message.Offset.y`` | The vertical distance in pixels the dialog is offset from the top left of the message box (not its bounding box)
 ``Graphics.<name>.Text.Message.Font`` | The name of the font (in fonts.tbl) to use for the dialog
 ``Graphics.<name>.Text.Message.UnderTitle`` | true if the dialog should be additionally vertically offset by the height of the title text (if it exists). false otherwise
 ``Graphics.<name>.Text.Title.Color[]`` | The R, G, B, A values of the menu choices
-``Graphics.<name>.Text.Title.Offset.x`` | The horizontal distance in pixels the menu choices are offset from the top left of the message box (not it's bounding box)
-``Graphics.<name>.Text.Title.Offset.y`` | The vertical distance in pixels the menu choices are offset from the top left of the message box (not it's bounding box)
+``Graphics.<name>.Text.Title.Offset.x`` | The horizontal distance in pixels the menu choices are offset from the top left of the message box (not its bounding box)
+``Graphics.<name>.Text.Title.Offset.y`` | The vertical distance in pixels the menu choices are offset from the top left of the message box (not its bounding box)
 ``Graphics.<name>.Text.Title.Font`` | The name of the font (in fonts.tbl) to use for the menu choices
 ``Graphics.<name>.MsgBox.File`` | The image file used for the message box background (expected in the interface directory)
 ``Graphics.<name>.MsgBox.Bounding.Top`` | The distance between the top edge of the image and writable text area
@@ -253,14 +253,14 @@ The following options from SHOW are available and behave comparably:
 
 
 #### MOVE
-The MOVE command can modify some options of a character (mostly positional) set by it's SHOW command or a previous MOVE command. The time in seconds over which the options get applied (i.e. the time the actor needs to move to the new target) is specified by the additional option ``time``, which is 1 by default. ``xflip`` and ``yflip`` are exceptions to this, as they are applied at the start of the move. Syntax:
+The MOVE command can modify some options of a character (mostly positional) set by its SHOW command or a previous MOVE command. The time in seconds over which the options get applied (i.e. the time the actor needs to move to the new target) is specified by the additional option ``time``, which is 1 by default. ``xflip`` and ``yflip`` are exceptions to this, as they are applied at the start of the move. Syntax:
 ```
 MOVE <id> [time=<time>] [list of options]
 ```
 Available options to change: ``x``, ``y``. ``xflip``, ``yflip``, ``scale``, ``alpha``.
 The most common use of this command is to move the actors on the screen.
 #### CHANGE
-The CHANGE command can modify most other options of a character set by it's SHOW command or a previous CHANGE command. All changes by the CHANGE command happen instantly. Syntax:
+The CHANGE command can modify most other options of a character set by its SHOW command or a previous CHANGE command. All changes by the CHANGE command happen instantly. Syntax:
 ```
 CHANGE <id> [list of options]
 ```
@@ -287,7 +287,7 @@ HIDE ALL [NOW]
 ```
 
 #### ACTION
-The ACTION command can be used to directly influence VN behavior. It's first parameter determines which action is to be performed, while the usage of the following parameters depends on the action.
+The ACTION command can be used to directly influence VN behavior. Its first parameter determines which action is to be performed, while the usage of the following parameters depends on the action.
 List of actions:
 Action | Result & Usage
 -|-
@@ -330,7 +330,7 @@ SETFLAG <variable> <bit number>
 
 ### Control Flow
 #### LABEL
-The LABEL command marks it's position in the script. It can be used to jump to this position from a GOTO command or enter the VN script there from a SEXP. If placed within an IF, ELSEIF or ELSE block, the remaining ELSEIF and ELSE blocks for this IF will be skipped, as if the condition of the block encapsulating the LABEL had naturally been fulfilled. Syntax:
+The LABEL command marks its position in the script. It can be used to jump to this position from a GOTO command or enter the VN script there from a SEXP. If placed within an IF, ELSEIF or ELSE block, the remaining ELSEIF and ELSE blocks for this IF will be skipped, as if the condition of the block encapsulating the LABEL had naturally been fulfilled. Syntax:
 ```
 LABEL <label name>
 ```
@@ -386,7 +386,7 @@ option | effect | default
 -|-|-
 x | The x coordinate of the display relative to the screen size. | 0.5
 y | The y coordinate of the display relative to the screen size. | 0.5
-align | Where the x coordinate refers to on the display. Can be LEFT (edge of it's background image), RIGHT (edge of it's background image) or CENTER. | LEFT
+align | Where the x coordinate refers to on the display. Can be LEFT (edge of its background image), RIGHT (edge of its background image) or CENTER. | LEFT
 
 #### HIDEDISPLAY
 HIDEDISPLAY hides a previously shown display with a defined ID. Syntax:
@@ -401,7 +401,7 @@ SETFONT [font name]
 ```
 
 #### PLAY
-PLAY is a command that is used to play various kinds of audio. It's first argument defines if it is music, a game sound or an interface sound. If music is to be played, the argument ONCE can be appended to specify that the music should not loop. In addition, playing music will make sure that music previously started by the PLAY command is stopped. Music is played by filename, while game and interface sounds are played by their table IDs
+PLAY is a command that is used to play various kinds of audio. Its first argument defines if it is music, a game sound or an interface sound. If music is to be played, the argument ONCE can be appended to specify that the music should not loop. In addition, playing music will make sure that music previously started by the PLAY command is stopped. Music is played by filename, while game and interface sounds are played by their table IDs
 Syntax for music:
 ```
 PLAY MUSIC <filename> [ONCE]
@@ -444,7 +444,7 @@ HIDEMAPICON <id>
 ```
 
 #### SHOWMAP
-The SHOWMAP command is what actually shows the map and blocks the script until the player made an input. It's first argument defines which variable will contain the index of the room the player clicked on. SHOWMAP can be called multiple times with the same map. This does not need multiple calls to LOADMAP. Do note though, that the position of the player icon (if it is displayed with SETMAPICON) will change to whichever room the player clicked last if SHOWMAP is called again. An optional second parameter can be NOFADE to indicate that the map should not fade out after it. The flag option defined which buttons are clickable, equivalent to MENU. Note that this only works to up to 32 buttons. Currently, the buttons only get activated after 0.5 seconds after displaying the map to avoid accidental clicking. Syntax:
+The SHOWMAP command is what actually shows the map and blocks the script until the player made an input. Its first argument defines which variable will contain the index of the room the player clicked on. SHOWMAP can be called multiple times with the same map. This does not need multiple calls to LOADMAP. Do note though, that the position of the player icon (if it is displayed with SETMAPICON) will change to whichever room the player clicked last if SHOWMAP is called again. An optional second parameter can be NOFADE to indicate that the map should not fade out after it. The flag option defined which buttons are clickable, equivalent to MENU. Note that this only works to up to 32 buttons. Currently, the buttons only get activated after 0.5 seconds after displaying the map to avoid accidental clicking. Syntax:
 ```
 SHOWMAP <target variable> [NOFADE] [flag=<flag>]
 ```

--- a/vn/README.md
+++ b/vn/README.md
@@ -293,10 +293,11 @@ Action | Result & Usage
 -|-
 FADEIN | Fades the screen from a solid color to the current image. The first parameter after the  FADEIN is the time in seconds (0 by default), the following three the color in RGB (black by default). Syntax:<br> ```ACTION FADEIN [time] [colorR] [colorG] [colorB]```
 FADEOUT | Fades the screen the current image to a solid color. Parameters equivalent to FADEIN. Syntax:<br> ```ACTION FADEOUT [time] [colorR] [colorG] [colorB]```
-LOCKDOWN | Locks the players ship (disables weapons, afterburner, ETS, gets taken over by AI with play dead command, as well as increases deceleration by a thousand). With the everything flag set, it will also set the ship flags immobile, protect-ship, afterburners-locked, primaries-locked and secondaries-locked. Syntax:<br> ```ACTION LOCKDOWN [EVERYTHING]```
+LOCKDOWN | Locks the players ship (disables weapons, afterburner, ETS, gets taken over by AI with play dead command, as well as increases deceleration by a thousand). When used with EVERYTHING, it will also set the ship flags immobile, protect-ship, afterburners-locked, primaries-locked and secondaries-locked. Syntax:<br> ```ACTION LOCKDOWN [EVERYTHING]```
 UNLOCKDOWN | Undoes the player lock. Syntax:<br> ```ACTION UNLOCKDOWN```
+LOADSCENE | Loads a different VN file and immediately starts it, optionally at a specified label. VN-internal variables and other data from the current scene are carried over to the new scene. Syntax:<br> ```ACTION LOADSCENE [filename] [label]```
+ENDSCENE | Ends the VN sequence and returns to the active mission. When used with KEEPHUDHIDDEN, will not make the player's HUD visible. Can return to the VN via SEXP (the VN-internal variables will stay set). Use this after setting a trigger SEXP-variable to tell FRED the VN segment is over. Syntax:<br> ```ACTION ENDSCENE [KEEPHUDHIDDEN]```
 ENDMISSION | Ends the VN sequence and the mission. Syntax:<br> ```ACTION ENDMISSION```
-ENDSCENE | Ends the VN sequence and returns to the active mission. Can return to the VN via SEXP (the VN-internal variables will stay set). Use this after setting a trigger SEXP-variable to tell FRED the VN segment is over. Syntax:<br> ```ACTION ENDSCENE```
 HIDECURSOR | Hides the player's cursor. Syntax:<br> ```ACTION HIDECURSOR```
 SHOWCURSOR | Unhides the player's cursor. Syntax:<br> ```ACTION SHOWCURSOR```
 HIDEBOX | Hides the dialog box. Syntax:<br> ```ACTION HIDEBOX```

--- a/vn/changelog.md
+++ b/vn/changelog.md
@@ -12,3 +12,5 @@
 - Added the option to start VN fadeout from an external SEXP
 - Added the option to set whether the cursor should stay hidden when a VN is loaded from the SEXP
 - Added a configuration option that allows certain messages to be displayed retail-style and not through the VN
+## 3.2.0
+- Added the LOADSCENE action by Goober5000

--- a/vn/conversionguide.md
+++ b/vn/conversionguide.md
@@ -1,5 +1,5 @@
 # Visual Script Versioning Guide
-The current version of the script is version 3.1.0
+The current version of the script is version 3.2.0
 ## On Versioning
 From version 3.0.0 onwards, the Visual Script follows semantic versioning. This means, a new major version (the first number) represents a new version that is not backwards compatible, and old scripts must be modified. A new minor version (the second number) means that new features were added but the script is still fully backwards compatible, while the patch (the third number) represents bugfixes within the current scope of the API.
 ## Conversion Guides

--- a/vn/data/tables/vs3-sct.tbm
+++ b/vn/data/tables/vs3-sct.tbm
@@ -42,7 +42,7 @@ function VS3.randomItem(list)
 end
 
 function VS3:Init(hideCursor)
-	--THIS IS VERSION 3.0.3
+	--THIS IS VERSION 3.x
 	
 	
 	ba.print("*****Initializing Visual Novel System...\n")
@@ -164,12 +164,6 @@ end
 
 mn.LuaSEXPs["lua-vn-load"].Action = function(filename, start, hideCursor)
 
-	local ext = ".txt"
-	
-	if not filename:ends(ext) then
-		filename = filename .. ext
-	end
-
 	-- simulate not supplying the "start" argument if we're forced to supply it
 	if start then
 		if start == "" or start:lower() == "none" then
@@ -181,12 +175,6 @@ mn.LuaSEXPs["lua-vn-load"].Action = function(filename, start, hideCursor)
 
 end
 
-function VS3:L(filename, start, stayInGame)
-
-	self:LoadScene{filename=filename .. ".txt", start=start, stayInGame=stayInGame}
-	
-end
-
 function VS3:LoadScene(args)
 
 	-- use table syntax in case one or more of the args isn't specified
@@ -194,6 +182,12 @@ function VS3:LoadScene(args)
 	local start = args.start
 	local stayInGame = args.stayInGame
 	local hideCursor = args.hideCursor
+	local skipInit = args.skipInit
+
+	local ext = ".txt"
+	if not filename:ends(ext) then
+		filename = filename .. ext
+	end
 
 	if not cf.fileExists(filename, "data/fiction", true) then
 		ba.error("VN Script: File " .. filename .. " was not found!\n")
@@ -204,9 +198,11 @@ function VS3:LoadScene(args)
 			start = string.lower(start)
 		end
 	
+	if not skipInit then
 		VS3:Init(hideCursor)
 		
 		if Lockdown and self.Config.LockByDefault then Lockdown() end
+	end
 		
 		local config = self.Config
 
@@ -221,7 +217,8 @@ function VS3:LoadScene(args)
 		self.Scene.ProcessLine = self.ProcessLine
 		self.Scene.EvalIf = self.EvalIf
 		self.Scene.ScanToNextELSEIFOrENDIF = self.ScanToNextELSEIFOrENDIF
-		
+
+	if not skipInit then
 		self.Enabled = true
 		self.StayInGame = stayInGame
 		
@@ -272,6 +269,7 @@ function VS3:LoadScene(args)
 			self.Anchor = AXMessage.Position.y
 			self.Anchor_pct = self.Anchor / AXUI.Screen.h
 		end
+	end
 		
 		--track current depth of nested if's
 		self.Scene.IfDepth = 0
@@ -294,7 +292,9 @@ function VS3:LoadScene(args)
 			self.Scene.Line = 0
 		end
 		
+	if not skipInit then
 		self:PreloadGraphics()
+	end
 		self.Scene:NextLine()
 		
 end
@@ -675,16 +675,22 @@ function VS3:Action(t)
 	--  3+ = parameter
 	
 	local action = string.lower(t[2])
-	
+
 	local t3types
-	if action == "lockdown" or action == "endscene" then
-		t3types = {"number", "string"}
+	if action == "lockdown" or action == "endscene" or action == "loadscene" then
+		t3types = "string"
 	else
 		t3types = "number"
 	end
+	local t4types
+	if action == "loadscene" then
+		t4types = "string"
+	else
+		t4types = "number"
+	end
 	
 	axemParse:Validate("line " .. self.Scene.Line .. ": argument 1", t[3], t3types, true)
-	axemParse:Validate("line " .. self.Scene.Line .. ": argument 2", t[4], "number", true)
+	axemParse:Validate("line " .. self.Scene.Line .. ": argument 2", t[4], t4types, true)
 	axemParse:Validate("line " .. self.Scene.Line .. ": argument 3", t[5], "number", true)
 	axemParse:Validate("line " .. self.Scene.Line .. ": argument 4", t[6], "number", true)
 	
@@ -741,6 +747,11 @@ function VS3:Action(t)
 			io.setCursorHidden(true)
 		end
 		VS3:Exit(true, nil, t[3] and string.lower(t[3])=="keephudhidden")		--keepvars=true, initflag=nil
+	elseif action == "loadscene" then
+		if t[3] then
+			ba.print("VN: Loading Scene " .. t[3] .. "!\n")
+			VS3:LoadScene{filename=t[3], start=t[4], skipInit=true}
+		end
 	elseif action == "hidecursor" then
 		io.setCursorHidden(true)
 		VS3.ShowCursor = false


### PR DESCRIPTION
LOADSCENE causes a scene to run right into another scene, skipping the process of unloading one scene and loading the next.  This allows VN stories to be broken into chunks without requiring everything to be in one file.