### PR TITLE
upgrade the Countdown script with a slight change and some new options

### DIFF
--- a/Countdown/data/missions/CountdownTest.fs2
+++ b/Countdown/data/missions/CountdownTest.fs2
@@ -1,7 +1,7 @@
 #Mission Info
 
 $Version: 0.10
-$Name:  XSTR("Untitled", -1)
+$Name:  XSTR("Countdown Test", -1)
 $Author: Joel Reimer
 $Created: 02/10/18 at 21:26:02
 $Modified: 07/03/20 at 18:57:03
@@ -187,8 +187,11 @@ $Formula: ( when
    ( lua-countdown-setup 
       -15 
       ( true ) 
-      2 
+      90 
       ( true ) 
+      "CountdownStart" 
+      30 
+      "CountdownChirp" 
    )
    ( lua-countdown-start ) 
 )

--- a/Countdown/data/tables/countdown-sct.tbm
+++ b/Countdown/data/tables/countdown-sct.tbm
@@ -178,7 +178,7 @@ end
 
 function Countdown:MaybeChangeBeepInterval(CurrentTime)
 
-	--Normally the counter will beep once a second. If its under a minute left and its going down, it quickens to 2 times a second
+	--Normally the counter will beep once a second. If its under a minute left, it quickens to 2 times a second
 	--Under 15 seconds, 4 times a second. Under 1 second, it's a near constant tone
 
 	if (self.Direction == 1) and (CurrentTime < 0) or (self.Direction == -1) and (CurrentTime > 0) then

--- a/Countdown/data/tables/countdown-sct.tbm
+++ b/Countdown/data/tables/countdown-sct.tbm
@@ -21,7 +21,7 @@ function Countdown:Init()
 	self.StartingCountdown = -90 --This the InitialValue of the countdown
 	self.TimeOnClock = 0 --The time for the clock
 	self.Status = 0 --0 = stopped, 1 = start counting, 2 = currently counting
-	self.Direction = 1 -- +1 = going up, -1 going down (you would still want to go UP for a countdown because the time is a negative value)
+	self.Direction = 1 -- +1 = positive, -1 = negative
 	self.TimeStartedAt = 0 -- The gametime we started at, will compare to the actual gametime to see where in the countdown we are
 	self.Color = {192,0,0} --RGB
 	self.Digits = {	"megatimer_0000", 		-- 0
@@ -43,18 +43,17 @@ function Countdown:Init()
 					"megatimersign_0000"}
 	self.BrokenTime = {} -- We'll store the broken up time here
 	self.Symbol = {blank = 90, minus = 91, colon = 92, dot = 93} -- Special characters, you don't need to modify this
-	
-	--Use sound.tbl/tbm entries here!
-	self.ActivateSound = ad.getSoundentry("CountdownStart") -- The sound.tbl index for when the time is first displayed
-	self.DeactivateSound = ad.getSoundentry(30) -- The sound.tbl index for when we stop the timer
-	self.BeepSound = ad.getSoundentry("CountdownChirp") -- The sound.tbl index for the beeping
-	
+
+	self.ActivateSound = nil
+	self.DeactivateSound = nil
+	self.BeepSound = nil
+
 	self.NextBeep = 0 --Next time we should do a tick/beep
 	self.BeepInterval = 1 --How often the timer will beep
-	self.SoundOn = 1 --Should be be beeping?
-	self.StopAtZero = 1 --Do we stop at zero or flip over?
+	self.BeepThreshold = -1 --Should be be beeping?
+	self.StopAtZero = true --Do we stop at zero or flip over?
 	self.Done = nil
-	
+
 	ba.print("*****Initializing Countdown System...\n")
 
 end
@@ -78,32 +77,32 @@ function Countdown:BreakTime(currentTime)
 	minutes = ((math.abs(currentTime)) /  60) % 60 --Calculate minutes, seconds and centiseconds
 	seconds = ((math.abs(currentTime))) % 60
 	centiseconds = ((math.abs(currentTime)) % 1) * 100
-	
+
 	--Grab the tens and ones digit (and add one since the table we'll be referring to starts at 1 and not 0)
 	min_tens = math.floor((minutes % 100) /10) + 1
 	min_ones = math.floor((minutes % 10)) + 1
-	
+
 	sec_tens = math.floor((seconds % 100) /10) + 1
 	sec_ones = math.floor((seconds % 10)) + 1
-	
+
 	cen_tens = math.floor((centiseconds % 100) /10) + 1
 	cen_ones = math.floor((centiseconds % 10)) + 1
-	
+
 	self.brokenTime = {signPlace, min_tens, min_ones, self.Symbol.colon, sec_tens, sec_ones, self.Symbol.dot, cen_tens, cen_ones}
 
 end
 
 function Countdown:DrawTime(currentTime)
-	
+
 	self:BreakTime(currentTime)
-		
+
 	for i = 1, 9 do
-		
+
 		local thisX, thisY = self:GetTimeCoords(i)
 		local drawChar = self.Digits[11] --Initialize to draw a blank by default
-		
+
 		gr.setColor(self.Color[1],self.Color[2],self.Color[3])
-		
+
 		--Decide what to draw
 		if self.brokenTime[i] == self.Symbol.blank then
 			drawChar = self.Digits[11]
@@ -114,42 +113,44 @@ function Countdown:DrawTime(currentTime)
 		elseif self.brokenTime[i] == self.Symbol.dot then
 			drawChar = self.Dot[1]
 		elseif (type(self.brokenTime[i]) == "number") and (self.brokenTime[i] < 11) then
-			drawChar = self.Digits[self.brokenTime[i]]	
+			drawChar = self.Digits[self.brokenTime[i]]
 		end
-		
+
 		gr.drawImage(drawChar, thisX, thisY, thisX+self.DigitSize.x, thisY+self.DigitSize.y, 0,0,1,1,1, true)
-	
-	end	
+
+	end
 
 end
 
 function Countdown:UpdateTime(theTime)
 
 	if self.Status == 1 then --Initialize the time we started the counter
+
 		self.Status = 2
 		self.TimeStartedAt = theTime
+
 	elseif self.Status == 2 then
-	
-		local internalTimer = theTime - self.TimeStartedAt
-	
+
+		local elapsedTime = theTime - self.TimeStartedAt
+
 		if self.Direction == 1 then
-			if self.StopAtZero == 0 or (self.StopAtZero == 1 and (internalTimer + self.StartingCountdown) < 0 ) then
-				self.TimeOnClock = self.StartingCountdown + internalTimer
+			if (not self.StopAtZero) or (self.StopAtZero and (self.StartingCountdown + elapsedTime) < 0) then
+				self.TimeOnClock = self.StartingCountdown + elapsedTime
 			else
 				self.TimeOnClock = 0
 				self.Done = true
 				self.Status = 0
 			end
 		else
-			if self.StopAtZero == 0 or (self.StopAtZero == 1 and (self.StartingCountdown - internalTimer) > 0 ) then
-				self.TimeOnClock = self.StartingCountdown - internalTimer
+			if (not self.StopAtZero) or (self.StopAtZero and (self.StartingCountdown - elapsedTime) > 0) then
+				self.TimeOnClock = self.StartingCountdown - elapsedTime
 			else
 				self.TimeOnClock = 0
 				self.Done = true
 				self.Status = 0
 			end
 		end
-		
+
 	end
 
 end
@@ -158,15 +159,14 @@ function Countdown:ChangeTime(newTime)
 
 	self.TimeStartedAt = mn.getMissionTime()
 	self.StartingCountdown = newTime
-	self.TimeOnClock = Countdown.StartingCountdown
-	
+	self.TimeOnClock = self.StartingCountdown
 
 end
 
 function Countdown:MaybeBeep(CurrentTime) -- Beep when we're running the clock every interval
 
 	if self.Status == 2 then
-		if self.SoundOn == 1 or (self.SoundOn == 2 and (math.abs(self.TimeOnClock) < 90)) then
+		if self.BeepThreshold == -1 or (self.BeepThreshold > 0 and (math.abs(self.TimeOnClock) < self.BeepThreshold)) then
 			if CurrentTime > self.NextBeep then
 				ad.playSound(self.BeepSound)
 				self.NextBeep = CurrentTime + self.BeepInterval
@@ -182,122 +182,16 @@ function Countdown:MaybeChangeBeepInterval(CurrentTime)
 	--Under 15 seconds, 4 times a second. Under 1 second, it's a near constant tone
 
 	if (self.Direction == 1) and (CurrentTime < 0) or (self.Direction == -1) and (CurrentTime > 0) then
-		if math.abs(CurrentTime) < 1.5 and self.BeepInterval ~= 0.005 then
+		local AbsoluteCurrentTime = math.abs(CurrentTime)
+		if AbsoluteCurrentTime < 1.5 and self.BeepInterval ~= 0.005 then
 			self.BeepInterval = 0.005
-		elseif math.abs(CurrentTime) < 15 and math.abs(CurrentTime) >= 1.5 and self.BeepInterval ~= 0.25 then
+		elseif AbsoluteCurrentTime < 15 and AbsoluteCurrentTime >= 1.5 and self.BeepInterval ~= 0.25 then
 			self.BeepInterval = 0.25
-		elseif math.abs(CurrentTime) < 61 and math.abs(CurrentTime) >= 15 and self.BeepInterval ~= 0.5 then
+		elseif AbsoluteCurrentTime < 61 and AbsoluteCurrentTime >= 15 and self.BeepInterval ~= 0.5 then
 			self.BeepInterval = 0.5
-		elseif math.abs(CurrentTime) > 61 and self.BeepInterval ~= 1 then
+		elseif AbsoluteCurrentTime > 61 and self.BeepInterval ~= 1 then
 			self.BeepInterval = 1
 		end
-	end
-
-end
-
-function cdSet(cdTime) --Sets the countdown to a time and displays it (but doesn't start it)
-
-	if type(cdTime) == "number" then
-		
-		if not Countdown.Enabled then
-			Countdown:Init()
-		end
-		Countdown.Enabled = true
-		Countdown.StartingCountdown = cdTime
-		Countdown.TimeOnClock = Countdown.StartingCountdown
-		Countdown.Done = nil
-		
-		if Countdown.SoundOn > 0 then
-			ad.playSound(Countdown.ActivateSound)
-		end
-	else
-	
-	ba.error("cdSet() was not given a number")
-	
-	end
-
-end
-
-function cdDirection(updown) --Determines the direction, 1 = up, -1 = down (defaults to up)
-
-	if updown ~= -1 or updown ~= 1 then
-		updown = 1
-	end
-	
-	Countdown.Direction = updown
-
-end
-
-function cdStart() --Start the countdown (or countup)
-
-	Countdown.Status = 1
-	Countdown.Done = nil
-
-end
-
-function cdPause() --Pauses the countdown, but doesn't remove it
-
-	Countdown.Status = 0
-	
-end
-
-function cdStop() --Stop the countdown and makes the counter vanish
-
-	if Countdown.Enabled then
-		Countdown.Enabled = false
-		Countdown.Status = 0
-		if Countdown.SoundOn > 0 then
-			ad.playSound(Countdown.DeactivateSound)
-		end
-	end
-	
-end
-
-function cdSoundOn(beepnumber) -- Alters the beeping, 0 = no beep, 1 = always beep, 2 = beep under 90 seconds
-
-	Countdown.SoundOn = beepnumber
-end
-
-function cdStopZero(yesno) -- Do we stop at zero or flip over? 0 = no, anything else = yes
-
-	if yesno == 0 then
-		Countdown.StopAtZero = 0
-	else
-		Countdown.StopAtZero = 1
-	end
-
-end
-
-function cdGetTime() -- Returns the time in SECONDS (Using it with SEXPs will chop off the decimal part)
-
-	if not Countdown.Enabled then
-		return 0
-	end
-
-	return tonumber(Countdown.TimeOnClock)
-
-end
-
-function cdGetTimeMs() -- Returns the time in MILLISECONDS (Using it with SEXPs will chop off the decimal part)
-	
-	if not Countdown.Enabled then
-		return 0
-	end
-	
-	return Countdown.TimeOnClock * 1000
-
-end
-
-function cdTrigger()
-
-	if Countdown.Enabled then
-		if Countdown.TimeOnClock == 0 then
-			return 1
-		else
-			return 0
-		end
-	else
-		return -1
 	end
 
 end
@@ -324,32 +218,85 @@ function Countdown:Exit()
 	self.BeepSound = nil
 	self.NextBeep = nil
 	self.BeepInterval = nil
-	self.SoundOn = nil
+	self.BeepThreshold = nil
 	self.StopAtZero = nil
 	self.Done = nil
 
 end
 
+-- set up a block for local functions
+do
+local cd = Countdown
 
-mn.LuaSEXPs["lua-countdown-setup"].Action = function(timeonclock, direction, sound, stopatzero)
+local function cdSet(cdTime) --Sets the countdown to a time and displays it (but doesn't start it)
 
-	cdSet(timeonclock)
+	if type(cdTime) == "number" then
+		cd.Enabled = true
+		cd.StartingCountdown = cdTime
+		cd.TimeOnClock = cd.StartingCountdown
+		cd.Done = nil
 
-	if direction then Countdown.Direction = 1 else Countdown.Direction = -1 end
-
-	Countdown.SoundOn = sound
-	
-	if stopatzero then Countdown.StopAtZero = 1 else Countdown.StopAtZero = 0 end
+		if cd.ActivateSound then
+			ad.playSound(cd.ActivateSound)
+		end
+	else
+		ba.error("cdSet() was not given a number")
+	end
 
 end
 
-mn.LuaSEXPs["lua-countdown-start"].Action = function() cdStart() end
-mn.LuaSEXPs["lua-countdown-pause"].Action = function() cdPause() end
-mn.LuaSEXPs["lua-countdown-stop"].Action = function() cdStop() end
-mn.LuaSEXPs["lua-countdown-get-time"].Action = function() 
+local function cdStart() --Start the countdown (or countup)
 
-	if Countdown.Enabled then
-		return tonumber(Countdown.TimeOnClock) 
+	cd.Status = 1
+	cd.Done = nil
+
+end
+
+local function cdPause() --Pauses the countdown, but doesn't remove it
+
+	cd.Status = 0
+
+end
+
+local function cdStop() --Stop the countdown and makes the counter vanish
+
+	if cd.Enabled then
+		cd.Enabled = false
+		cd.Status = 0
+		if cd.DeactivateSound then
+			ad.playSound(cd.DeactivateSound)
+		end
+	end
+
+end
+
+
+mn.LuaSEXPs["lua-countdown-setup"].Action = function(timeonclock, direction, beep_threshold, stopatzero, activate, deactivate, beep)
+
+	if not cd.Enabled then
+		cd:Init()
+	end
+	if activate:isValid() and activate:tryLoad() then cd.ActivateSound = activate else cd.ActivateSound = nil end
+	if deactivate:isValid() and deactivate:tryLoad() then cd.DeactivateSound = deactivate else cd.DeactivateSound = nil end
+	if beep:isValid() and beep:tryLoad() then cd.BeepSound = beep else cd.BeepSound = nil end
+
+	cdSet(timeonclock)
+
+	if direction then cd.Direction = 1 else cd.Direction = -1 end
+
+	cd.BeepThreshold = beep_threshold
+
+	cd.StopAtZero = stopatzero
+
+end
+
+mn.LuaSEXPs["lua-countdown-start"].Action = cdStart
+mn.LuaSEXPs["lua-countdown-pause"].Action = cdPause
+mn.LuaSEXPs["lua-countdown-stop"].Action = cdStop
+mn.LuaSEXPs["lua-countdown-get-time"].Action = function()
+
+	if cd.Enabled then
+		return tonumber(cd.TimeOnClock)
 	else
 		return -32762
 	end
@@ -357,49 +304,54 @@ end
 
 mn.LuaSEXPs["lua-countdown-get-time-ms"].Action = function()
 
-	if Countdown.Enabled then
-		return tonumber(Countdown.TimeOnClock * 1000)
+	if cd.Enabled then
+		return tonumber(cd.TimeOnClock) * 1000
 	else
 		return -32762
 	end
 end
 
 mn.LuaSEXPs["lua-countdown-done"].Action = function()
-	if Countdown.Done then
+	if cd.Done then
 		return true
-	else 
-		return false 
-	end 
+	else
+		return false
+	end
+end
+
+-- end of block for local functions
 end
 
 ]
 
-$State: GS_STATE_GAME_PLAY
-$On Gameplay Start:
+$On Mission Start:
 [
 	Countdown:Exit()
 ]
-$On State End:
+
+$On Mission End:
 [
 	if Countdown.Enabled then
 		Countdown:Exit()
 	end
 ]
+
+$State: GS_STATE_GAME_PLAY
 $On Frame:
 [
-	if Countdown.Enabled then
-		Countdown:UpdateTime(mn.getMissionTime())
-		
-		if Countdown.SoundOn > 0 then
-			Countdown:MaybeBeep(mn.getMissionTime())
-			Countdown:MaybeChangeBeepInterval(Countdown.TimeOnClock)
+	local cd = Countdown
+	if cd.Enabled then
+		cd:UpdateTime(mn.getMissionTime())
+
+		if cd.BeepThreshold ~= 0 then
+			cd:MaybeBeep(mn.getMissionTime())
+			cd:MaybeChangeBeepInterval(cd.TimeOnClock)
 		end
-		
+
 		if hu.HUDDrawn and (gr.hasViewmode(VM_INTERNAL) or gr.hasViewmode(VM_CHASE)) then
-			Countdown:DrawTime(Countdown.TimeOnClock)
+			cd:DrawTime(cd.TimeOnClock)
 		end
 	end
-		
 ]
 
 #End

--- a/Countdown/data/tables/countdown-sexp.tbm
+++ b/Countdown/data/tables/countdown-sexp.tbm
@@ -14,7 +14,7 @@ $Parameter:
 	+Description: Count direction. If true, countdown will count positive. If false, countdown will count negative.
 	+Type: boolean
 $Parameter:
-	+Description: Beep option. If 0, no beep is used. If -1, you'll get a beep every second. Any positive number will be a threshold that will cause beeps to start when the countdown's distance from 0 is within this number. Beeping increases in frequency the lower the timer.
+	+Description: Beep option. If 0, no beep is used. If -1, you'll get a beep every second for the entire count. Any positive number will be a threshold that will cause beeps to start when the countdown's distance from 0 is within this number. Beeping is normally once a second$semicolon but it will quicken to twice a second when the distance from 0 is within 60 seconds, four times a second within 15 seconds, and near-constant within 1 second.
 	+Type: number
 $Parameter:
 	+Description: Whether to stop at zero. If true, the countdown will stop at zero, if false, it will continue counting after passing zero.

--- a/Countdown/data/tables/countdown-sexp.tbm
+++ b/Countdown/data/tables/countdown-sexp.tbm
@@ -3,23 +3,33 @@
 $Operator: lua-countdown-setup
 $Category: Change
 $Subcategory: Scripted
-$Minimum Arguments: 4
-$Maximum Arguments: 4
+$Minimum Arguments: 7
+$Maximum Arguments: 7
 $Return Type: Nothing
-$Description: Sets up the scripted countdown system. Must be done before lua-countdown-start. Just a note at the confusing nature of "counting down" and the count direction works. If you want a countdown, you need a negative time on clock and a positive count direction, so the count heads to 0. You can also have a positive time on clock and negative count direction, that heads to 0 as well. Just as long as it heads to zero that's all that matters! If you want to just have a generic timer that counts up, just set time on clock to 0.
+$Description: Sets up the scripted countdown system. Must be done before lua-countdown-start. Just a note at the confusing nature of "counting down" and the count direction works. If you use a negative time on the clock and a positive count direction, the count heads to 0. You can also have a positive time on clock and negative count direction that heads to 0 as well. Just as long as it heads to zero that's all that matters! If you want to just have a generic timer that counts up, just set time on clock to 0.
 $Parameter:
-	+Description: Time on clock. If you are performing a countdown, you should probably make this a negative number. If you are doing a timer, make this zero.
+	+Description: Time on clock. This can be a positive or negative number. If you are doing a timer, make this zero.
 	+Type: number
 $Parameter:
-	+Description: Count direction. If true, countdown will count positive (up). If false, countdown will count negative (down).
+	+Description: Count direction. If true, countdown will count positive. If false, countdown will count negative.
 	+Type: boolean
 $Parameter:
-	+Description: Sound option. If 0, no sound is used. If 1, you'll get a beep every second. If 2, you'll only get beeps under 90 seconds. Beeping increases in frequency the lower the timer.
+	+Description: Beep option. If 0, no beep is used. If -1, you'll get a beep every second. Any positive number will be a threshold that will cause beeps to start when the countdown's distance from 0 is within this number. Beeping increases in frequency the lower the timer.
 	+Type: number
 $Parameter:
-	+Description: Stop at zero. If true, the countdown will stop at zero, if false, it will continue counting after passing zero.
+	+Description: Whether to stop at zero. If true, the countdown will stop at zero, if false, it will continue counting after passing zero.
 	+Type: boolean
-	
+$Parameter:
+	+Description: Sound to play when the countdown is activated.  Can be <none>.
+	+Type: soundentry
+$Parameter:
+	+Description: Sound to play when the countdown is deactivated.  Can be <none>.
+	+Type: soundentry
+$Parameter:
+	+Description: Sound to play when the countdown is beeping.  Can be <none>.
+	+Type: soundentry
+
+
 $Operator: lua-countdown-start
 $Category: Change
 $Subcategory: Scripted


### PR DESCRIPTION
This enhances the Countdown script based on its use case in Inferno: Nostos.  Users of the script should be mindful that these changes introduce minor compatibility breaks and remove the ability to call the functions directly using `script-eval`.  All calls are done exclusively through the scripted SEXPs.

1. The "up" and "down" terms have been replaced with "positive" and "negative" so that it is clear exactly how the script is counting.
2. It is now possible to specify the beep threshold, although this slightly changes the meaning of the old "sound" parameter.
3. The activate, deactive, and beep sounds are now specified through the SEXP and can be set to `<none>`.
4. Obsolete functions have been removed and minor bugfixes (e.g. consistent use of `tonumber`) have been added.