### PR TITLE
call setClip() when calling setScreenScale()

### DIFF
--- a/MarkBox/data/tables/markbox-sct.tbm
+++ b/MarkBox/data/tables/markbox-sct.tbm
@@ -402,13 +402,18 @@ function MarkBox:DrawSubsystemBracket(subsys, data)
 			end
 			
 			if data.Text then
-				local savedFont = gr.CurrentFont
+				local prevFont = gr.CurrentFont
 				gr.CurrentFont = self.FONT
 				local xt, yt = self:RescaleCoords(nx2+5, ny2-20)
+				local prevResizeMode = gr.CurrentResizeMode
+				gr.CurrentResizeMode = GR_RESIZE_FULL
 				gr.setScreenScale(self.BASE_WIDTH, self.BASE_HEIGHT)
-				gr.drawStringResized(GR_RESIZE_FULL, data.Text, xt, yt)
+				gr.setClip(0, 0, self.BASE_WIDTH, self.BASE_HEIGHT)
+				gr.drawString(data.Text, xt, yt)
 				gr.resetScreenScale()
-				gr.CurrentFont = savedFont
+				gr.resetClip()
+				gr.CurrentFont = prevFont
+				gr.CurrentResizeMode = prevResizeMode
 			end
 
 			if self.DrawSubsysHealth and subsys.HitpointsMax > 0 then
@@ -446,13 +451,18 @@ function MarkBox:DrawShipBracket(ship, data)
 		if data.Text then
 			local x1,y1,x2,y2 = gr.drawTargetingBrackets(ship, false)
 			if x1 and y1 then
-				local savedFont = gr.CurrentFont
+				local prevFont = gr.CurrentFont
 				gr.CurrentFont = self.FONT
 				local xt, yt = self:RescaleCoords(x1-5, y1-16)
+				local prevResizeMode = gr.CurrentResizeMode
+				gr.CurrentResizeMode = GR_RESIZE_FULL
 				gr.setScreenScale(self.BASE_WIDTH, self.BASE_HEIGHT)
-				gr.drawStringResized(GR_RESIZE_FULL, data.Text, xt, yt)
+				gr.setClip(0, 0, self.BASE_WIDTH, self.BASE_HEIGHT)
+				gr.drawString(data.Text, xt, yt)
 				gr.resetScreenScale()
-				gr.CurrentFont = savedFont
+				gr.resetClip()
+				gr.CurrentFont = prevFont
+				gr.CurrentResizeMode = prevResizeMode
 			end
 		end
 	end

--- a/ScrollWrite/data/tables/scrollwrite-sct.tbm
+++ b/ScrollWrite/data/tables/scrollwrite-sct.tbm
@@ -134,8 +134,12 @@ function Scroll:Draw()
 
 		local numLines = #self.Lines
 	if numLines > 0 then
+		local prevResizeMode
 		if self.UseConfig then
+			prevResizeMode = gr.CurrentResizeMode
+			gr.CurrentResizeMode = GR_RESIZE_FULL
 			gr.setScreenScale(self.BaseWidth, self.BaseHeight)
+			gr.setClip(0, 0, self.BaseWidth, self.BaseHeight)
 		end
 
 		for i = 1, numLines do
@@ -183,12 +187,8 @@ function Scroll:Draw()
 							x = x - (gr.getStringWidth(line.Text)/2)
 						end
 
-						if self.UseConfig then
-							gr.drawStringResized(GR_RESIZE_FULL,displayString,x,y)
-						else
 						gr.drawString(displayString,x,y)
 					end
-				end
 				end
 			else
 				table.remove(self.Lines,i)
@@ -202,6 +202,8 @@ function Scroll:Draw()
 
 		if self.UseConfig then
 			gr.resetScreenScale()
+			gr.resetClip()
+			gr.CurrentResizeMode = prevResizeMode
 		end
 		if savedFont then
 			gr.CurrentFont = savedFont


### PR DESCRIPTION
In most places in the FreeSpace code, and always when displaying text, a call to set the screen scale is always followed by a call to set the clipping region.  So, make sure the same is done in all relevant scripts in this repository.  Without this fix, text can be cut off at high resolutions because the engine is using a clipping region smaller than the drawing area.