### PR TITLE
enhance lockdown sexp

### DIFF
--- a/AxMiscFunctions/data/tables/misc-sc-functions-sct.tbm
+++ b/AxMiscFunctions/data/tables/misc-sc-functions-sct.tbm
@@ -71,7 +71,9 @@ if not noplaydead then
 end
 
 if isPlayer then
-	mn.evaluateSEXP("(lock-perspective (true)))")
+	mn.evaluateSEXP("(lock-perspective (true) 0 " ..
+;;FSO 24.2.0;;       "(true)" ..
+	")")
 	mn.evaluateSEXP("(ignore-key !-1! !T! !H! !F! !Shift-T! !Shift-H! !Alt-H! !Shift-F! !Alt-M! !Alt-J! )")
 end
 
@@ -117,7 +119,9 @@ mn.evaluateSEXP("(player-not-use-ai)")
 mn.evaluateSEXP("(clear-goals !" .. name .. "!)")
 
 if isPlayer then
-	mn.evaluateSEXP("(lock-perspective (false) )")
+	mn.evaluateSEXP("(lock-perspective (false) 0 " ..
+;;FSO 24.2.0;;       "(false)" ..
+	")")
 	mn.evaluateSEXP("(ignore-key !0! !T! !H! !F! !Shift-T! !Shift-H! !Alt-H! !Shift-F! !Alt-M! !Alt-J! )")
 end
 


### PR DESCRIPTION
By default, the `lock-perspective` sexp still allows the view to be changed via the padlock, or joystick hat.  This adds the optional argument to also lock the hat view if the current build is 24.2 or greater.

Depends on https://github.com/scp-fs2open/fs2open.github.com/pull/6219.