### PR TITLE
fix deprecation in PromptBox

### DIFF
--- a/PromptBox/data/tables/proBox-sct.tbm
+++ b/PromptBox/data/tables/proBox-sct.tbm
@@ -519,9 +519,15 @@ end
 function PromptBox:Respond(value)
 
 	local data = self.PromptData[self.ActivePrompt]
-	
+
 	data.LastResult = value
+
+;; In 21.4, addBit was deprecated and replaced with setBit
+;;FSO 21.4.0;; 	data.Bitfield = bit.setBit(data.Bitfield, value)
+;;FSO 21.4.0;; !*
 	data.Bitfield = bit.addBit(data.Bitfield, value)
+;;FSO 21.4.0;; *!
+
 	if data.Variable then data.Variable.Value = data.Bitfield end
 
 end


### PR DESCRIPTION
The `addBit` function was introduced in 21.0 but was then deprecated and replaced by `setBit` in 21.4.  Mods targeting recent FSO versions were not able to use PromptBox due to the deprecation.  This PR allows the script to work for both 21.0-21.4 and post-21.4 builds.