### PR TITLE
update MarkBox and TurretHotkey

### DIFF
--- a/MarkBox/data/tables/markbox-sct.tbm
+++ b/MarkBox/data/tables/markbox-sct.tbm
@@ -56,7 +56,6 @@ function MarkBox:AddSubsys(ship, text, ...)
 				end]]--
 
 				self.List[self:DoesEntryExist(t) or #self.List+1] = t
-
 			end
 		end
 	end
@@ -297,7 +296,7 @@ function MarkBox:Draw()
 				
 					local targetSS = mn.getObjectFromSignature(thisEntry.Key)[thisEntry.Target]
 					
-					if targetSS:isValid() and targetSS.HitpointsLeft > 0 then
+					if targetSS:isValid() and (targetSS.HitpointsMax == 0 or targetSS.HitpointsLeft > 0) then
 						self:DrawSubsystemBracket(targetSS, thisEntry)	
 					else
 						table.remove(self.List,i)

--- a/TurretHotkey/data/tables/turrethotkey-sct.tbm
+++ b/TurretHotkey/data/tables/turrethotkey-sct.tbm
@@ -3,18 +3,23 @@ $Application: FS2_Open
 
 $On Game Init:
 [
-
 TurretHotkey = {}
 
 function TurretHotkey:Init()
 
 	self.Enabled = nil
 
+	-- use MarkBox if present, otherwise use MarkerManager
+	self.MarkBox = MarkBox
+	if not self.MarkBox then
+		self.MarkerManager = require('mark')
+	end
+
 	TurretHotkey:ClearAll()
 
 end
 
-function TurretHotkey:ClearAll(markboxtoo)
+function TurretHotkey:ClearAll()
 
 	self.List = {}
 	--Structure of List
@@ -24,23 +29,23 @@ function TurretHotkey:ClearAll(markboxtoo)
 	--Structure of position
 	--self.CurrentPosition[key, index]
 	
-	if markboxtoo and MarkBox then
-		MarkBox:ClearList()
+	if self.MarkBox then
+		self.MarkBox:ClearList()
 	end
 
 end
 
 mn.LuaSEXPs["lua-turrethotkey-clear-all"].Action = function()
 
-	TurretHotkey:ClearAll(true)
+	TurretHotkey:ClearAll()
 
 end
 
-function TurretHotkey:Add(key, ship, subsystem, usemarkbox)
+function TurretHotkey:Add(key, ship, subsystem, text)
 
 	self.Enabled = true
 
-	if ship:isValid() and ship[subsystem]:isValid() then
+	if ship:isValid() and subsystem:isValid() then
 
 		if not self.List[key] then
 			self.List[key] = {}
@@ -49,20 +54,24 @@ function TurretHotkey:Add(key, ship, subsystem, usemarkbox)
 		local entry = self.List[key]
 		local t = {}
 		t.Ship = ship
-		t.Subsystem = ship[subsystem]
+		t.Subsystem = subsystem
 		entry[#entry+1] = t
-		
-		if usemarkbox and MarkBox then
-			MarkBox:AddSubsys(ship, usemarkbox, {subsystem})
+
+		if text then
+			if self.MarkBox then
+				self.MarkBox:AddSubsys(ship, text, {subsystem:getModelName()})
+			else
+				self.MarkerManager:forShip(ship):forSubsystem(subsystem):setText(text)
+			end
 		end
-		
+
 	end
 
 end
 
-mn.LuaSEXPs["lua-turrethotkey-add"].Action = function(key, ship, subsystem, usemarkbox)
+mn.LuaSEXPs["lua-turrethotkey-add"].Action = function(key, ship, subsystem, text)
 
-	TurretHotkey:Add(key, ship, subsystem, usemarkbox)
+	TurretHotkey:Add(key, ship, subsystem, text)
 
 end
 
@@ -116,7 +125,7 @@ function TurretHotkey:GetEntry(ship, subsystem)
 			end
 	end
 	
-	ba.print("DID NOT FIND SUBSYSTEM!\n")
+	ba.print("TurretHotkey: DID NOT FIND SUBSYSTEM!\n")
 end
 
 function TurretHotkey:Remove(ship, subsystem)
@@ -134,12 +143,17 @@ function TurretHotkey:Remove(ship, subsystem)
 		end
 	end
 
+	if self.MarkBox then
+		self.MarkBox:ClearSubsys(ship, {subsystem:getModelName()})
+	else
+		self.MarkerManager:forShip(ship):forSubsystem(subsystem):setActive(false)
+	end
+
 end
 
 mn.LuaSEXPs["lua-turrethotkey-remove"].Action = function(ship, subsystem)
 
 	TurretHotkey:Remove(ship, subsystem)
-	if MarkBox then MarkBox:ClearSubsys(ship, {subsystem}) end
 
 end
 

--- a/TurretHotkey/data/tables/turrethotkey-sexp.tbm
+++ b/TurretHotkey/data/tables/turrethotkey-sexp.tbm
@@ -1,8 +1,8 @@
 #Lua SEXPs
-	
+
 $Operator: lua-turrethotkey-add
 $Category: Change
-$Subcategory: Scripted
+$Subcategory: Targeting and Brackets
 $Minimum Arguments: 3
 $Maximum Arguments: 4
 $Return Type: Nothing
@@ -15,14 +15,15 @@ $Parameter:
 	+Type: Ship
 $Parameter:
 	+Description: Turret to assign
-	+Type: String
+	+Type: subsystem
+	+Parent Parameter Index: 2
 $Parameter:
-	+Description: If this is filled out and the MarkBox script is installed, the turret will be highlighted with the text drawn next to it
+	+Description: A label to mark the turret with (requires the MarkBox or MarkerManager script to be present)
 	+Type: String
-	
+
 $Operator: lua-turrethotkey-remove
 $Category: Change
-$Subcategory: Scripted
+$Subcategory: Targeting and Brackets
 $Minimum Arguments: 2
 $Maximum Arguments: 2
 $Return Type: Nothing
@@ -32,14 +33,15 @@ $Parameter:
 	+Type: Ship
 $Parameter:
 	+Description: Turrets to assign
-	+Type: String
-	
+	+Type: subsystem
+	+Parent Parameter Index: 1
+
 $Operator: lua-turrethotkey-clear-all
 $Category: Change
-$Subcategory: Scripted
+$Subcategory: Targeting and Brackets
 $Minimum Arguments: 0
 $Maximum Arguments: 0
 $Return Type: Nothing
 $Description: Clears all the turret hotkey data. (NOTE: This will also clear all MarkBox list data too!)
-	
+
 #End


### PR DESCRIPTION
A few improvements and fixes based on work with Inferno...

1. Upload the most recent version of TurretHotkey which has been floating around and has a few refinements, notably subsystem parameters instead of string parameters, as well as MarkerManager support
2. Allow TurretHotkey to work with both MarkBox and MarkerManager, depending on which is installed
3. Fix a MarkBox bug where subsystems that have 0 maximum hitpoints (such as fighterbays) did not have brackets drawn on them