### PR TITLE
fix crashes in two scripts

### DIFF
--- a/SaveLoad/data/tables/shipsaveloadv2-sct.tbm
+++ b/SaveLoad/data/tables/shipsaveloadv2-sct.tbm
@@ -82,17 +82,19 @@ $On Game Init:
 			local entry = mn.ShipRegistry[shipname]
 			if entry and entry.Status == NOT_YET_PRESENT then
 				local parsed = entry:getParsedShip()
-				local wing = parsed:getWing()
-				if wing:isValid() then
-					if wing.TotalArrived == 0 then
-						wing.ArrivalLocation = "Hyperspace"
-						wing:setFlag(true, "no-arrival-warp", "no-arrival-music", "no-arrival-message")
-						wing:makeWingArrive()
+				if parsed:isValid() then	-- if it's not valid, it's the support ship
+					local wing = parsed:getWing()
+					if wing:isValid() then
+						if wing.TotalArrived == 0 then
+							wing.ArrivalLocation = "Hyperspace"
+							wing:setFlag(true, "no-arrival-warp", "no-arrival-music", "no-arrival-message")
+							wing:makeWingArrive()
+						end
+					else
+						parsed.ArrivalLocation = "Hyperspace"
+						parsed:setFlag(true, "no-arrival-warp", "no-arrival-music")
+						parsed:makeShipArrive()
 					end
-				else
-					parsed.ArrivalLocation = "Hyperspace"
-					parsed:setFlag(true, "no-arrival-warp", "no-arrival-music")
-					parsed:makeShipArrive()
 				end
 			end
 		end

--- a/TurretHotkey/data/tables/turrethotkey-sct.tbm
+++ b/TurretHotkey/data/tables/turrethotkey-sct.tbm
@@ -143,10 +143,12 @@ function TurretHotkey:Remove(ship, subsystem)
 		end
 	end
 
-	if self.MarkBox then
-		self.MarkBox:ClearSubsys(ship, {subsystem:getModelName()})
-	else
-		self.MarkerManager:forShip(ship):forSubsystem(subsystem):setActive(false)
+	if ship:isValid() and subsystem:isValid() then
+		if self.MarkBox then
+			self.MarkBox:ClearSubsys(ship, {subsystem:getModelName()})
+		else
+			self.MarkerManager:forShip(ship):forSubsystem(subsystem):setActive(false)
+		end
 	end
 
 end

--- a/TurretHotkey/data/tables/turrethotkey-sexp.tbm
+++ b/TurretHotkey/data/tables/turrethotkey-sexp.tbm
@@ -29,7 +29,7 @@ $Maximum Arguments: 2
 $Return Type: Nothing
 $Description: Removes a turret hotkey entry
 $Parameter:
-	+Description: Ship has has the turret
+	+Description: Ship that has the turret
 	+Type: Ship
 $Parameter:
 	+Description: Turrets to assign


### PR DESCRIPTION
1. There is an edge case in FSO where a support ship is marked NOT_YET_PRESENT but is not actually on the arrival list.  Check for this situation in the SaveLoad script and don't try to inspect the parsed ship if it doesn't exist.
2. In TurretHotkey, don't try to remove an entry where the ship and subsystem are not valid (usually because the ship has been destroyed).

Fixes crashes encountered in Inferno.