### PR TITLE
patch AxUi for instant launch

### DIFF
--- a/AxBase/data/scripts/axui.lua
+++ b/AxBase/data/scripts/axui.lua
@@ -26,6 +26,8 @@ function AXUI:Init()
 	self.Fonts.Old = nil
 	
 	self.MouseButton = {false, false, false}
+	self.MouseX = 0
+	self.MouseY = 0
 	
 end
 


### PR DESCRIPTION
If a mod is launched without moving the mouse, the x and y coordinates will not be initialized before they are used.  To fix this, initialize them to 0.

Bug noticed and fix confirmed by @dariusbei.