### PR TITLE
fix a bug in the TurretHotkey script

### DIFF
--- a/TurretHotkey/data/tables/turrethotkey-sct.tbm
+++ b/TurretHotkey/data/tables/turrethotkey-sct.tbm
@@ -45,6 +45,10 @@ function TurretHotkey:Add(key, ship, subsystem, text)
 
 	self.Enabled = true
 
+	if type(subsystem) == "string" and ship:isValid() and ship[subsystem]:isValid() then
+		subsystem = ship[subsystem]
+	end
+
 	if ship:isValid() and subsystem:isValid() then
 
 		if not self.List[key] then


### PR DESCRIPTION
Do the same subsystem resolution in `TurretHotkey:Add` that we do in `TurretHotkey:Remove`.  Fixes a bug discovered in Inferno.